### PR TITLE
[TASK] Add slack.neos.io to selector in header

### DIFF
--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/Page/Default.html
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/Page/Default.html
@@ -43,6 +43,7 @@
 									<li><a href="https://discuss.neos.io">discuss.neos.io</a></li>
 									<li><a href="https://jira.neos.io">jira.neos.io</a></li>
 									<li><a href="http://review.typo3.org">review.typo3.org</a></li>
+									<li><a href="http://slack.neos.io">slack.neos.io</a></li>
 								</ul>
 							</li>
 						</ul>


### PR DESCRIPTION
This adds slack.neos.io to the site selector in the page header. A link
to the actual slack web chat UI will be added there, so this should
suffice.