### PR TITLE
[TASK] Add translate.neos.io to selector in header

### DIFF
--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/Page/Default.html
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/Page/Default.html
@@ -44,6 +44,7 @@
 									<li><a href="https://jira.neos.io">jira.neos.io</a></li>
 									<li><a href="http://review.typo3.org">review.typo3.org</a></li>
 									<li><a href="http://slack.neos.io">slack.neos.io</a></li>
+									<li><a href="http://translate.neos.io">translate.neos.io</a></li>
 								</ul>
 							</li>
 						</ul>


### PR DESCRIPTION
This adds translate.neos.io to the site selector in the page header.