### PR TITLE
FIX: getting filtering for funding types

### DIFF
--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/FundingBadges.html
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/FundingBadges.html
@@ -12,6 +12,7 @@
             </div>
         </div>
 
+        <span style="display: none">{badgeData.badgeTypes.0}</span>
         <ul class="tiles--filters list-unstyled">
             <f:for each="{badgeData.badgeTypes}" as="type" key="label">
                 <li data-filter="{label -> f:format.case(mode: 'lower')}">


### PR DESCRIPTION
When the filtering is needed for rendering, the filters 
are not already been fetched. 
It is no nice, but working solution, to fetch them beforehand
so they are cached and there when needed.