### PR TITLE
TASK: Limit the navigate component tree depth to 1

### DIFF
--- a/Packages/Sites/Neos.NeosIo/Configuration/Settings.yaml
+++ b/Packages/Sites/Neos.NeosIo/Configuration/Settings.yaml
@@ -1,0 +1,8 @@
+TYPO3:
+
+  Neos:
+
+    userInterface:
+      navigateComponent:
+        nodeTree:
+          loadingDepth: 1


### PR DESCRIPTION
This change limit the navigate component tree depth to 1 now that we have
a bit more documents in the tree it's more comfortable.