### PR TITLE
TASK: Tweak footer text

### DIFF
--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/Page/Partials/SiteFooter.html
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/Page/Partials/SiteFooter.html
@@ -35,7 +35,8 @@
 	</div>
 
 	<p class="u-alignCenter u-mt1/1">
-		Created by over
+		Neos is free and open source software licensed under <a href="https://opensource.org/licenses/GPL-3.0" target="_blank" rel="noopener">GPL v3</a> or later.<br />
+		Created with passion by over
 		<span
 			data-component="GitHubAPI"
 			data-endpoint="repos/Neos/neos-development-collection/stats/contributors"
@@ -47,6 +48,7 @@
 				<i class="spinner__dot"></i>
 			</span>
 		</span>
-		contributors under the <a href="http://opensource.org/licenses/MIT" target="_blank" rel="noopener">MIT License</a>.
+		contributors around the world.<br />
+		Website hosted by <a href="https://www.flownative.com" target="_blank" rel="noopener">Flownative</a>.
 	</p>
 </footer>


### PR DESCRIPTION
This corrects the license mentioned in the footer (Neos is GPL, not MIT)
and adds a hint about Flownative being the hosting sponsor.
