### PR TITLE
BUGFIX: improvements to SentenceSwitcher

### DIFF
--- a/Packages/Sites/Neos.NeosIo/Resources/Public/JavaScript/Bundle.min.js
+++ b/Packages/Sites/Neos.NeosIo/Resources/Public/JavaScript/Bundle.min.js
@@ -826,7 +826,11 @@ function mapSentenceToParts(sentence) {
   * Characters that remain that remain a part of the word include:
   *   -#$%^&_`~'
   */
-		if (endChar.match(/[\.,"\/!\?\*\+;:{}=()\[\]\s]/g)) {
+		if (endChar == '|') {
+			components.push('');
+			// The start of the next word is the next character to be seen.
+			start = end + 1;
+		} else if (endChar.match(/[\.,"\/!\?\*\+;:{}=()\[\]\s]/g)) {
 			// Append the word we've been building
 			if (end > start) {
 				var part = sentence.slice(start, end);
@@ -947,7 +951,7 @@ var SentenceSwitcher = (_dec = (0, _component.component)({
 				var nextIndex = currentIndex + 2 > sentences.length ? 0 : currentIndex + 1;
 
 				_this2.animateToIndex(nextIndex);
-			}, 8000);
+			}, 4000);
 		}
 	}, {
 		key: 'animateToIndex',
@@ -967,23 +971,42 @@ var SentenceSwitcher = (_dec = (0, _component.component)({
 				var currentText = node.innerHTML;
 				var newPart = targetSentence[index];
 
-				if (!newPart) {
-					node.innerHTML = '';
-					return;
-				}
-
+				// The animation works as follows: (applying the FLIP technique: https://aerotwist.com/blog/flip-your-animations/)
+				//
+				// 0-0.5s: the class .headlineSlider__word--isAnimating is appended to the elements which change.
+				//         This hides the words to be removed via CSS transitions. (0.5 secs)
+				// 0.5s: a JS timeout fires; replacing the text to the new content; but manually sizing the width of the elements
+				//       to the *old* size. Effectively, the DOM changes but the visual representation stays the same.
+				// 0.5s-1s: we animate the sizing change using CSS transitions. (inline styles)
+				// 1.1s: we remove the class .headlineSlider__word--isAnimating, leading to the fade-in of the new word.
+				// 1.1s-1.6s: the word is faded in again.
 				if (currentText !== newPart) {
 					var finishAnimation = function finishAnimation() {
-						node.innerHTML = newPart;
-						node.classList.remove(animatingWordClassName);
+
+						var oldWidth = currentText ? node.getBoundingClientRect().width : 0;
+						node.innerHTML = newPart || '';
+						var newWidth = newPart ? node.getBoundingClientRect().width : 0;
+
+						// This doubly-nested requestAnimationFrame is needed to have the animation run smoothly in firefox.
+						requestAnimationFrame(function () {
+							// Before the DOM paints, Invert it to its old position
+							node.style.width = oldWidth + 'px';
+							node.style.transition = 'width 0s';
+							requestAnimationFrame(function () {
+								node.style.width = newWidth + 'px';
+								node.style.transition = 'width 500ms';
+
+								setTimeout(function () {
+									node.style.width = '';
+									node.style.transition = '';
+									node.classList.remove(animatingWordClassName);
+								}, 600);
+							});
+						});
 					};
 					node.classList.add(animatingWordClassName);
 
-					if (currentText) {
-						setTimeout(finishAnimation, 1000);
-					} else {
-						finishAnimation();
-					}
+					setTimeout(finishAnimation, 500);
 				}
 			});
 


### PR DESCRIPTION
- now without jerky animations :-)
- the | symbol is the placeholder for an "empty" token (which you need to fine tune animations)
