### PR TITLE
FEATURE: Refactor references

### DIFF
--- a/Packages/Sites/Neos.NeosIo/Configuration/NodeTypes.Reference.List.yaml
+++ b/Packages/Sites/Neos.NeosIo/Configuration/NodeTypes.Reference.List.yaml
@@ -1,0 +1,30 @@
+'Neos.NeosIo:Reference.List':
+  superTypes: ['TYPO3.Neos:Content']
+  ui:
+    label: 'Reference List'
+    icon: 'icon-globe'
+    group: 'special'
+    inspector:
+      groups:
+        'properties':
+          label: Reference list properties
+          position: 1
+  properties:
+    'projectType':
+      type: references
+      ui:
+        label: 'Project types to show'
+        reloadIfChanged: true
+        inspector:
+          group: 'properties'
+          editorOptions:
+            nodeTypes: ['Neos.NeosIo:ReferenceType']
+    'projectTypeIgnored':
+      type: references
+      ui:
+        label: 'Project types to ignore'
+        reloadIfChanged: true
+        inspector:
+          group: 'properties'
+          editorOptions:
+            nodeTypes: ['Neos.NeosIo:ReferenceType']

--- a/Packages/Sites/Neos.NeosIo/Configuration/NodeTypes.Reference.ShowCase.yaml
+++ b/Packages/Sites/Neos.NeosIo/Configuration/NodeTypes.Reference.ShowCase.yaml
@@ -1,0 +1,5 @@
+'Neos.NeosIo:Reference.ShowCase':
+  superTypes:
+    'Neos.NeosIo:Reference': TRUE
+  ui:
+    label: 'Show Case'

--- a/Packages/Sites/Neos.NeosIo/Configuration/NodeTypes.Reference.yaml
+++ b/Packages/Sites/Neos.NeosIo/Configuration/NodeTypes.Reference.yaml
@@ -5,7 +5,9 @@
     icon: 'icon-tag'
 
 'Neos.NeosIo:Reference':
-  superTypes: ['TYPO3.Neos:Document']
+  superTypes:
+    'TYPO3.Neos:Document': TRUE
+  abstract: TRUE
   ui:
     label: 'Reference'
     icon: 'icon-globe'
@@ -15,6 +17,15 @@
           label: Reference properties
           position: 1
   properties:
+    'url':
+      type: string
+      ui:
+        label: 'Project URL'
+        reloadIfChanged: TRUE
+        inspector:
+          group: 'properties'
+          editor: 'TYPO3.Neos/Inspector/Editors/LinkEditor'
+          position: 10
     'image':
       type: TYPO3\Media\Domain\Model\ImageInterface
       ui:
@@ -24,21 +35,6 @@
           group: 'properties'
           position: 20
     'projectType':
-      type: string
-      defaultValue: 'customer'
-      ui:
-        reloadIfChanged: TRUE
-        label: 'Choose project type'
-        inspector:
-          editor: Content/Inspector/Editors/SelectBoxEditor
-          group: 'properties'
-          editorOptions:
-            values:
-              'customer':
-                label: 'Customer Project'
-              'agency':
-                label: 'Agency/Usergroup Website'
-    'typeOfProject':
       type: reference
       ui:
         label: 'Choose project type'
@@ -47,6 +43,8 @@
           group: 'properties'
           editorOptions:
             nodeTypes: ['Neos.NeosIo:ReferenceType']
+      search:
+        fulltextExtractor: ${Indexing.extractInto('h2', value.properties.title)}
     'launchDate':
       type: DateTime
       ui:
@@ -55,6 +53,8 @@
           group: 'properties'
       validation:
         'TYPO3.Neos/Validation/DateTimeValidator': []
+      search:
+        indexing: '${(value ? Date.format(value, "Y-m-d\TH:i:sP") : null)}'
     'datePublished':
       type: DateTime
       ui:
@@ -63,8 +63,11 @@
           group: 'properties'
       validation:
         'TYPO3.Neos/Validation/DateTimeValidator': []
+      search:
+        indexing: '${(value ? Date.format(value, "Y-m-d\TH:i:sP") : null)}'
     'projectVolume':
       type: string
+      defaultValue: '1'
       ui:
         reloadIfChanged: TRUE
         label: 'Project volume'
@@ -76,49 +79,12 @@
               '1':
                 label: 'Unknown'
               '5':
-                label: '< 10.000 € (< 100 h)'
+                label: '< 100 h'
               '10':
-                label: '10.000 - 49.999 € (100 - 499h)'
+                label: '100 - 499h'
               '15':
-                label: '50.000 - 99.999 € (500 - 999h)'
+                label: '500 - 999h'
               '20':
-                label: '100.000 - 300.000 € (1000 - 3000h)'
+                label: '1000 - 3000h'
               '25':
-                label: '> 300.000 € (> 3000h)'
-
-'Neos.NeosIo:ReferenceList':
-  superTypes: ['TYPO3.Neos:Content']
-  ui:
-    label: 'Reference List'
-    icon: 'icon-globe'
-    group: 'special'
-    inspector:
-      groups:
-        'properties':
-          label: Reference list properties
-          position: 1
-  properties:
-    'projectType':
-      type: string
-      defaultValue: 'customer'
-      ui:
-        reloadIfChanged: TRUE
-        label: 'Reference Project Type'
-        inspector:
-          editor: Content/Inspector/Editors/SelectBoxEditor
-          group: 'properties'
-          editorOptions:
-            values:
-              'customer':
-                label: 'Customer Project'
-              'agency':
-                label: 'Agency/Usergroup Website'
-    'typeOfProject':
-      type: references
-      ui:
-        label: 'Project types to show'
-        reloadIfChanged: true
-        inspector:
-          group: 'properties'
-          editorOptions:
-            nodeTypes: ['Neos.NeosIo:ReferenceType']
+                label: '> 3000h'

--- a/Packages/Sites/Neos.NeosIo/Configuration/Objects.yaml
+++ b/Packages/Sites/Neos.NeosIo/Configuration/Objects.yaml
@@ -7,3 +7,6 @@ Neos\NeosIo\Service\FundingApiConnector:
         arguments:
           1:
             value: NeosNeosIo_FundingApiCache
+
+TYPO3\TYPO3CR\Search\Search\QueryBuilderInterface:
+  className: Neos\MarketPlace\Eel\ElasticSearchQueryBuilder

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Partials/Reference.List.Item.html
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Partials/Reference.List.Item.html
@@ -1,0 +1,6 @@
+{namespace media=TYPO3\Media\ViewHelpers}
+
+<f:if condition="{image}">
+	<media:image image="{image}" alt="{title}" maximumWidth="561" maximumHeight="261" allowCropping="true" allowUpScaling="false" />
+</f:if>
+<h3>{title}</h3>

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Partials/Reference.ShowCase.html
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Partials/Reference.ShowCase.html
@@ -1,0 +1,6 @@
+{namespace media=TYPO3\Media\ViewHelpers}
+
+<h1>{title}</h1>
+<f:if condition="{image}">
+	<media:image image="{image}" alt="{title}" maximumWidth="561" maximumHeight="261" allowCropping="true" allowUpScaling="false" />
+</f:if>

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Reference.List.Item.html
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Reference.List.Item.html
@@ -1,0 +1,14 @@
+{namespace media=TYPO3\Media\ViewHelpers}
+
+<div class="reference-item gi u-w1/1 u-wm1/2 u-wl1/2">
+	<f:if condition="{url}">
+		<f:then>
+			<a href="{url}">
+				<f:render partial="Reference.List.Item" arguments="{_all}" />
+			</a>
+		</f:then>
+		<f:else>
+			<f:render partial="Reference.List.Item" arguments="{_all}" />
+		</f:else>
+	</f:if>
+</div>

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Reference.List.html
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Reference.List.html
@@ -1,4 +1,3 @@
-{namespace neos=TYPO3\Neos\ViewHelpers}
 <div {attributes -> f:format.raw()}>
 	{references -> f:format.raw()}
 </div>

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Reference.ShowCase.html
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Reference.ShowCase.html
@@ -1,0 +1,14 @@
+{namespace media=TYPO3\Media\ViewHelpers}
+
+<div {attributes -> f:format.raw()}>
+	<f:if condition="{url}">
+		<f:then>
+			<a href="{url}">
+				<f:render partial="Reference.ShowCase" arguments="{_all}" />
+			</a>
+		</f:then>
+		<f:else>
+			<f:render partial="Reference.ShowCase" arguments="{_all}" />
+		</f:else>
+	</f:if>
+</div>

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/TypoScript/NodeTypes/Reference.List.ts2
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/TypoScript/NodeTypes/Reference.List.ts2
@@ -1,0 +1,23 @@
+prototype(Neos.NeosIo:Reference.List) < prototype(TYPO3.Neos:Content) {
+	references = TYPO3.TypoScript:Collection {
+		collection = ${Search.query(site).nodeType('Neos.NeosIo:Reference').sortDesc('datePublished').execute()}
+		itemName = 'node'
+		itemRenderer = Neos.NeosIo:Reference.List.Item
+	}
+
+	attributes {
+		class = TYPO3.TypoScript:RawArray {
+			list = 'reference-list'
+			grid = 'g'
+			@process.nodeType >
+		}
+	}
+}
+
+prototype(Neos.NeosIo:Reference.List.Item) < prototype(TYPO3.TypoScript:Template) {
+	templatePath = 'resource://Neos.NeosIo/Private/Templates/NodeTypes/Reference.List.Item.html'
+	title = ${q(node).property('title')}
+	image = ${q(node).property('image')}
+	url = ${q(node).property('url')}
+	datePublished = ${q(node).property('datePublished')}
+}

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/TypoScript/NodeTypes/Reference.ShowCase.ts2
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/TypoScript/NodeTypes/Reference.ShowCase.ts2
@@ -1,0 +1,22 @@
+/**
+* NodeTypes around Show Cases
+*/
+
+
+prototype(Neos.NeosIo:Reference.ShowCase.Document) < prototype(Neos.NeosIo:Reference.Document) {
+	body {
+		content {
+			main = Neos.NeosIo:Reference.ShowCase
+		}
+	}
+
+	@cache {
+		entryTags {
+			reference = 'NodeTypes_Neos.NeosIo:Reference'
+		}
+	}
+}
+
+prototype(Neos.NeosIo:Reference.ShowCase) < prototype(Neos.NeosIo:Reference) {
+	templatePath = 'resource://Neos.NeosIo/Private/Templates/NodeTypes/Reference.ShowCase.html'
+}


### PR DESCRIPTION
I added a config inside the Objects.yaml because otherwise ElasticSearch had a problem with the Marketplace's ElasticSearchQueryBuilder.

The properties projectType and projectTypeIgnored inside the listing element are not ready but don't break anything if used.

Currently we only have a listing of all Show Cases sorted by Date Published, newest first.
Styling is not added, only the rough markup for two column/one column layout.