### PR TITLE
TASK: Cache the main menu only once

### DIFF
--- a/Packages/Sites/Neos.NeosIo/Resources/Private/TypoScript/TypoScriptObjects/DefaultPage/FooterMenu.ts2
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/TypoScript/TypoScriptObjects/DefaultPage/FooterMenu.ts2
@@ -1,5 +1,12 @@
 prototype(Neos.NeosIo:DefaultPage.FooterMenu) < prototype(Menu) {
     templatePath = 'resource://Neos.NeosIo/Private/Templates/TypoScriptObjects/FooterMenu.html'
     attributes.class = 'nav nav--stacked siteFooter__nav'
-    itemCollection = ${q(site).children('[instanceof Neos.NeosIo:FooterContainer]').children('[instanceof TYPO3.Neos:Document]').get()}
+
+    footerContainer = ${q(site).children('[instanceof Neos.NeosIo:FooterContainer]').first()}
+    @context.footerContainer = ${footerContainer.get(0)}
+
+    itemCollection = ${q(this.footerContainer).children('[instanceof TYPO3.Neos:Document]').get()}
+
+    @cache.entryIdentifier.documentNode = ${site}
+    @cache.entryTags.1 = ${'DescendantOf_' + footerContainer.identifier}
 }

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/TypoScript/TypoScriptObjects/DefaultPage/Menu.ts2
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/TypoScript/TypoScriptObjects/DefaultPage/Menu.ts2
@@ -4,4 +4,5 @@ prototype(Neos.NeosIo:DefaultPage.Menu) < prototype(Menu) {
     maximumLevels = 2
     attributes.class = 'nav siteHeader__nav offCanvas__nav'
     filter = 'TYPO3.Neos:Document, !Neos.NeosIo:Reference'
+    @cache.entryIdentifier.documentNode = ${site}
 }


### PR DESCRIPTION
As the menu is exactly the same on all pages, it doe not make sense to generate an cache entry for every document. A single cache entry for the full site should be enough and can save some CPU cycle