### PR TITLE
FEATURE: Refactor references

### DIFF
--- a/Packages/Sites/Neos.NeosIo/Configuration/NodeTypes.Reference.List.yaml
+++ b/Packages/Sites/Neos.NeosIo/Configuration/NodeTypes.Reference.List.yaml
@@ -1,5 +1,6 @@
 'Neos.NeosIo:Reference.List':
-  superTypes: ['TYPO3.Neos:Content']
+  superTypes:
+    'TYPO3.Neos:Content': TRUE
   ui:
     label: 'Reference List'
     icon: 'icon-globe'

--- a/Packages/Sites/Neos.NeosIo/Configuration/NodeTypes.Reference.List.yaml
+++ b/Packages/Sites/Neos.NeosIo/Configuration/NodeTypes.Reference.List.yaml
@@ -1,0 +1,30 @@
+'Neos.NeosIo:Reference.List':
+  superTypes: ['TYPO3.Neos:Content']
+  ui:
+    label: 'Reference List'
+    icon: 'icon-globe'
+    group: 'special'
+    inspector:
+      groups:
+        'properties':
+          label: Reference list properties
+          position: 1
+  properties:
+    'projectType':
+      type: references
+      ui:
+        label: 'Project types to show'
+        reloadIfChanged: true
+        inspector:
+          group: 'properties'
+          editorOptions:
+            nodeTypes: ['Neos.NeosIo:ReferenceType']
+    'projectTypeIgnored':
+      type: references
+      ui:
+        label: 'Project types to ignore'
+        reloadIfChanged: true
+        inspector:
+          group: 'properties'
+          editorOptions:
+            nodeTypes: ['Neos.NeosIo:ReferenceType']

--- a/Packages/Sites/Neos.NeosIo/Configuration/NodeTypes.Reference.ShowCase.yaml
+++ b/Packages/Sites/Neos.NeosIo/Configuration/NodeTypes.Reference.ShowCase.yaml
@@ -1,0 +1,5 @@
+'Neos.NeosIo:Reference.ShowCase':
+  superTypes:
+    'Neos.NeosIo:Reference': TRUE
+  ui:
+    label: 'Show Case'

--- a/Packages/Sites/Neos.NeosIo/Configuration/NodeTypes.Reference.yaml
+++ b/Packages/Sites/Neos.NeosIo/Configuration/NodeTypes.Reference.yaml
@@ -5,7 +5,9 @@
     icon: 'icon-tag'
 
 'Neos.NeosIo:Reference':
-  superTypes: ['TYPO3.Neos:Document']
+  superTypes:
+    'TYPO3.Neos:Document': TRUE
+  abstract: TRUE
   ui:
     label: 'Reference'
     icon: 'icon-globe'
@@ -15,6 +17,15 @@
           label: Reference properties
           position: 1
   properties:
+    'url':
+      type: string
+      ui:
+        label: 'Project URL'
+        reloadIfChanged: TRUE
+        inspector:
+          group: 'properties'
+          editor: 'TYPO3.Neos/Inspector/Editors/LinkEditor'
+          position: 10
     'image':
       type: TYPO3\Media\Domain\Model\ImageInterface
       ui:
@@ -24,21 +35,6 @@
           group: 'properties'
           position: 20
     'projectType':
-      type: string
-      defaultValue: 'customer'
-      ui:
-        reloadIfChanged: TRUE
-        label: 'Choose project type'
-        inspector:
-          editor: Content/Inspector/Editors/SelectBoxEditor
-          group: 'properties'
-          editorOptions:
-            values:
-              'customer':
-                label: 'Customer Project'
-              'agency':
-                label: 'Agency/Usergroup Website'
-    'typeOfProject':
       type: reference
       ui:
         label: 'Choose project type'
@@ -47,6 +43,8 @@
           group: 'properties'
           editorOptions:
             nodeTypes: ['Neos.NeosIo:ReferenceType']
+      search:
+        fulltextExtractor: ${Indexing.extractInto('h2', value.properties.title)}
     'launchDate':
       type: DateTime
       ui:
@@ -55,6 +53,8 @@
           group: 'properties'
       validation:
         'TYPO3.Neos/Validation/DateTimeValidator': []
+      search:
+        indexing: '${(value ? Date.format(value, "Y-m-d\TH:i:sP") : null)}'
     'datePublished':
       type: DateTime
       ui:
@@ -63,8 +63,11 @@
           group: 'properties'
       validation:
         'TYPO3.Neos/Validation/DateTimeValidator': []
+      search:
+        indexing: '${(value ? Date.format(value, "Y-m-d\TH:i:sP") : null)}'
     'projectVolume':
       type: string
+      defaultValue: '1'
       ui:
         reloadIfChanged: TRUE
         label: 'Project volume'
@@ -76,49 +79,12 @@
               '1':
                 label: 'Unknown'
               '5':
-                label: '< 10.000 € (< 100 h)'
+                label: '< 100 h'
               '10':
-                label: '10.000 - 49.999 € (100 - 499h)'
+                label: '100 - 499h'
               '15':
-                label: '50.000 - 99.999 € (500 - 999h)'
+                label: '500 - 999h'
               '20':
-                label: '100.000 - 300.000 € (1000 - 3000h)'
+                label: '1000 - 3000h'
               '25':
-                label: '> 300.000 € (> 3000h)'
-
-'Neos.NeosIo:ReferenceList':
-  superTypes: ['TYPO3.Neos:Content']
-  ui:
-    label: 'Reference List'
-    icon: 'icon-globe'
-    group: 'special'
-    inspector:
-      groups:
-        'properties':
-          label: Reference list properties
-          position: 1
-  properties:
-    'projectType':
-      type: string
-      defaultValue: 'customer'
-      ui:
-        reloadIfChanged: TRUE
-        label: 'Reference Project Type'
-        inspector:
-          editor: Content/Inspector/Editors/SelectBoxEditor
-          group: 'properties'
-          editorOptions:
-            values:
-              'customer':
-                label: 'Customer Project'
-              'agency':
-                label: 'Agency/Usergroup Website'
-    'typeOfProject':
-      type: references
-      ui:
-        label: 'Project types to show'
-        reloadIfChanged: true
-        inspector:
-          group: 'properties'
-          editorOptions:
-            nodeTypes: ['Neos.NeosIo:ReferenceType']
+                label: '> 3000h'

--- a/Packages/Sites/Neos.NeosIo/Configuration/Objects.yaml
+++ b/Packages/Sites/Neos.NeosIo/Configuration/Objects.yaml
@@ -18,3 +18,5 @@ Neos\NeosIo\Service\CrowdApiConnector:
           1:
             value: NeosNeosIo_CrowdApiCache
 
+TYPO3\TYPO3CR\Search\Search\QueryBuilderInterface:
+  className: Neos\MarketPlace\Eel\ElasticSearchQueryBuilder

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Scss/Atoms/_Meta.scss
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Scss/Atoms/_Meta.scss
@@ -1,0 +1,21 @@
+//
+// A meta element
+//
+
+
+/**
+ * Meta element:
+ * F.e. footer-like meta information below something with smaller and lighter text
+ *
+ *     @example
+ *     p.meta This is a simple meta data line
+ *
+ */
+@mixin meta() {
+	@include u-microCopy();
+	color: $lighter-text;
+}
+
+.meta {
+	@include meta();
+}

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Scss/Main.scss
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Scss/Main.scss
@@ -45,6 +45,7 @@
 @import 'Atoms/_ScrollHint';
 @import 'Atoms/_Table';
 @import 'Atoms/_Typography';
+@import 'Atoms/_Meta';
 
 // Molecules
 @import 'Molecules/_FactsGrid';
@@ -59,6 +60,7 @@
 @import 'Molecules/_HeadlineSlider';
 @import 'Molecules/_ImageTeaser';
 @import 'Molecules/_FundingBadges';
+@import 'Molecules/_ReferencesList.scss';
 
 // Organisms
 @import 'Organisms/_SiteHeader';

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Scss/Molecules/_ReferencesList.scss
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Scss/Molecules/_ReferencesList.scss
@@ -1,0 +1,32 @@
+/**
+ * References:
+ * Layout for show cases
+ */
+
+.references__list {
+	.references__item {
+		&:nth-child(odd) {
+			clear: both;
+		}
+	}
+
+	.imageTeaser {
+		min-height: 250px;
+	}
+
+	.references__data {
+		@include meta();
+		@include u-invertText();
+		padding-top: 4px;
+
+		span {
+			display: block;
+			padding-right: 1em;
+			white-space: nowrap;
+
+			@include min-screen(400px) {
+				display: inline-block;
+			}
+		}
+	}
+}

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Scss/_Variables.scss
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Scss/_Variables.scss
@@ -138,6 +138,9 @@ $color-info: map-get($brand-colors, primary) !default;
 $color-positive: #8CD700 !default;
 $color-negative: #D75200 !default;
 
+// For certain atoms used colors
+$lighter-text: lighten(brand('teritary'), 35%);
+
 // Default styling for horizontal rules and bordered elements like tables.
 $basic-border-color: color-adjust($content-background, 10%) !default;
 $basic-border-style: solid !default;

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/ImageTeaser.html
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/ImageTeaser.html
@@ -3,10 +3,7 @@
 {namespace io=Neos\NeosIo\ViewHelpers}
 
 <io:link.external uri="{link}" openInNewTab="{openInNewTab}" noLinkWhen="{neos:rendering.inBackend()}" class="imageTeaser">
-	<svg class="imageTeaser__corner imageTeaser__corner--topLeft" xmlns="http://www.w3.org/2000/svg" version="1.1" id="Layer_1" x="0px" y="0px" width="28px" height="20px" viewBox="0 0 28 20" enable-background="new 0 0 28 20" xml:space="preserve">
-		<polygon xmlns="http://www.w3.org/2000/svg" stroke-miterlimit="20" points="0,0 0,20 28,0"/>
-		<line stroke-miterlimit="20" x1="0" y1="20" x2="28" y2="0"/>
-	</svg>
+	<f:render partial="CornerTopLeft" arguments="{_all}" />
 	<f:if condition="{image}">
 		<f:then>
 			<media:image
@@ -35,9 +32,6 @@
 		<neos:contentElement.editable property="subTitle" tag="h5" class="imageTeaser__contents__subHeading" />
 		<neos:contentElement.editable property="title" tag="h3" class="imageTeaser__contents__heading" />
 	</div>
-	<svg class="imageTeaser__corner imageTeaser__corner--bottomRight" xmlns="http://www.w3.org/2000/svg" version="1.1" id="Layer_1" x="0px" y="0px" width="28px" height="20px" viewBox="0 0 28 20" enable-background="new 0 0 28 20" xml:space="preserve">
-		<polygon xmlns="http://www.w3.org/2000/svg" stroke-miterlimit="20" points="28,20 0,20 28,0"/>
-		<line stroke-miterlimit="20" x1="0" y1="20" x2="28" y2="0"/>
-	</svg>
+	<f:render partial="CornerBottomRight" arguments="{_all}" />
 
 </io:link.external>

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Partials/CornerBottomRight.html
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Partials/CornerBottomRight.html
@@ -1,0 +1,4 @@
+<svg class="imageTeaser__corner imageTeaser__corner--bottomRight" xmlns="http://www.w3.org/2000/svg" version="1.1" id="Layer_1" x="0px" y="0px" width="28px" height="20px" viewBox="0 0 28 20" enable-background="new 0 0 28 20" xml:space="preserve">
+	<polygon xmlns="http://www.w3.org/2000/svg" stroke-miterlimit="20" points="28,20 0,20 28,0"/>
+	<line stroke-miterlimit="20" x1="0" y1="20" x2="28" y2="0"/>
+</svg>

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Partials/CornerTopLeft.html
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Partials/CornerTopLeft.html
@@ -1,0 +1,4 @@
+<svg class="imageTeaser__corner imageTeaser__corner--topLeft" xmlns="http://www.w3.org/2000/svg" version="1.1" id="Layer_1" x="0px" y="0px" width="28px" height="20px" viewBox="0 0 28 20" enable-background="new 0 0 28 20" xml:space="preserve">
+	<polygon xmlns="http://www.w3.org/2000/svg" stroke-miterlimit="20" points="0,0 0,20 28,0"/>
+	<line stroke-miterlimit="20" x1="0" y1="20" x2="28" y2="0"/>
+</svg>

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Partials/Reference.List.Item.html
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Partials/Reference.List.Item.html
@@ -1,0 +1,6 @@
+{namespace media=TYPO3\Media\ViewHelpers}
+
+<f:if condition="{image}">
+	<media:image image="{image}" alt="{title}" maximumWidth="561" maximumHeight="261" allowCropping="true" allowUpScaling="false" />
+</f:if>
+<h3>{title}</h3>

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Partials/Reference.List.Item.html
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Partials/Reference.List.Item.html
@@ -1,6 +1,46 @@
+{namespace neos=TYPO3\Neos\ViewHelpers}
 {namespace media=TYPO3\Media\ViewHelpers}
 
+<f:render partial="CornerTopLeft" arguments="{_all}" />
 <f:if condition="{image}">
-	<media:image image="{image}" alt="{title}" maximumWidth="561" maximumHeight="261" allowCropping="true" allowUpScaling="false" />
+	<media:image
+		class="imageTeaser__image"
+		asset="{image}"
+		title="{title}"
+		alt="{alternativeText}"
+		maximumWidth="700c"
+		maximumHeight="450c"
+		allowUpScaling="{allowUpScaling}"
+	/>
 </f:if>
-<h3>{title}</h3>
+
+<div class="imageTeaser__contents u-invertText">
+	<h3 class="imageTeaser__contents__heading">{title}</h3>
+	<footer class="references__data">
+		<f:if condition="{launchDate}"><span><i class="fa fa-rocket"></i> <f:format.date format="d.m.Y">{launchDate}</f:format.date></span></f:if>
+
+		<f:if condition="{projectVolume}">
+			<span>
+				<i class="fa fa-users"></i>
+				<f:if condition="{projectVolume} == 5">
+					< 100h
+				</f:if>
+				<f:if condition="{projectVolume} == 10">
+					100 - 499h
+				</f:if>
+				<f:if condition="{projectVolume} == 15">
+					500 - 999h
+				</f:if>
+				<f:if condition="{projectVolume} == 20">
+					1000 - 3000h
+				</f:if>
+				<f:if condition="{projectVolume} == 25">
+					> 3000h
+				</f:if>
+			</span>
+		</f:if>
+
+		<f:if condition="{projectType}"><span><i class="fa fa-industry"></i> {projectType}</span></f:if>
+	</footer>
+</div>
+<f:render partial="CornerBottomRight" arguments="{_all}" />

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Partials/Reference.ShowCase.html
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Partials/Reference.ShowCase.html
@@ -2,5 +2,32 @@
 
 <h1>{title}</h1>
 <f:if condition="{image}">
-	<media:image image="{image}" alt="{title}" maximumWidth="561" maximumHeight="261" allowCropping="true" allowUpScaling="false" />
+	<media:image image="{image}" alt="{title}" maximumWidth="561" maximumHeight="261" allowCropping="true" allowUpScaling="false" class="u-mb1/2" />
 </f:if>
+<ul>
+	<f:if condition="{launchDate}"><li><i class="fa fa-rocket"></i> <f:format.date format="d.m.Y">{launchDate}</f:format.date></li></f:if>
+
+	<f:if condition="{projectVolume}">
+			<li>
+				<i class="fa fa-users"></i>
+				<f:if condition="{projectVolume} == 5">
+					< 100h
+				</f:if>
+				<f:if condition="{projectVolume} == 10">
+					100 - 499h
+				</f:if>
+				<f:if condition="{projectVolume} == 15">
+					500 - 999h
+				</f:if>
+				<f:if condition="{projectVolume} == 20">
+					1000 - 3000h
+				</f:if>
+				<f:if condition="{projectVolume} == 25">
+					> 3000h
+				</f:if>
+			</li>
+	</f:if>
+
+	<f:if condition="{projectType}"><li><i class="fa fa-industry"></i> {projectType}</li></f:if>
+</ul>
+</footer>

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Partials/Reference.ShowCase.html
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Partials/Reference.ShowCase.html
@@ -1,0 +1,6 @@
+{namespace media=TYPO3\Media\ViewHelpers}
+
+<h1>{title}</h1>
+<f:if condition="{image}">
+	<media:image image="{image}" alt="{title}" maximumWidth="561" maximumHeight="261" allowCropping="true" allowUpScaling="false" />
+</f:if>

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Reference.List.Item.html
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Reference.List.Item.html
@@ -1,14 +1,16 @@
-{namespace media=TYPO3\Media\ViewHelpers}
+{namespace io=Neos\NeosIo\ViewHelpers}
 
-<div class="reference-item gi u-w1/1 u-wm1/2 u-wl1/2">
+<div class="references__item gi u-w1/1 u-wm1/2 u-wl1/2">
 	<f:if condition="{url}">
 		<f:then>
-			<a href="{url}">
+			<io:link.external uri="{url}" openInNewTab="{openInNewTab}" class="imageTeaser">
 				<f:render partial="Reference.List.Item" arguments="{_all}" />
-			</a>
+			</io:link.external>
 		</f:then>
 		<f:else>
-			<f:render partial="Reference.List.Item" arguments="{_all}" />
+			<div class="imageTeaser">
+				<f:render partial="Reference.List.Item" arguments="{_all}" />
+			</div>
 		</f:else>
 	</f:if>
 </div>

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Reference.List.Item.html
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Reference.List.Item.html
@@ -1,0 +1,14 @@
+{namespace media=TYPO3\Media\ViewHelpers}
+
+<div class="reference-item gi u-w1/1 u-wm1/2 u-wl1/2">
+	<f:if condition="{url}">
+		<f:then>
+			<a href="{url}">
+				<f:render partial="Reference.List.Item" arguments="{_all}" />
+			</a>
+		</f:then>
+		<f:else>
+			<f:render partial="Reference.List.Item" arguments="{_all}" />
+		</f:else>
+	</f:if>
+</div>

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Reference.List.html
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Reference.List.html
@@ -1,4 +1,3 @@
-{namespace neos=TYPO3\Neos\ViewHelpers}
 <div {attributes -> f:format.raw()}>
 	{references -> f:format.raw()}
 </div>

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Reference.ShowCase.html
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Reference.ShowCase.html
@@ -1,0 +1,14 @@
+{namespace media=TYPO3\Media\ViewHelpers}
+
+<div {attributes -> f:format.raw()}>
+	<f:if condition="{url}">
+		<f:then>
+			<a href="{url}">
+				<f:render partial="Reference.ShowCase" arguments="{_all}" />
+			</a>
+		</f:then>
+		<f:else>
+			<f:render partial="Reference.ShowCase" arguments="{_all}" />
+		</f:else>
+	</f:if>
+</div>

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/TypoScript/NodeTypes/Reference.List.ts2
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/TypoScript/NodeTypes/Reference.List.ts2
@@ -7,7 +7,7 @@ prototype(Neos.NeosIo:Reference.List) < prototype(TYPO3.Neos:Content) {
 
 	attributes {
 		class = TYPO3.TypoScript:RawArray {
-			list = 'reference-list'
+			list = 'references__list'
 			grid = 'g'
 			@process.nodeType >
 		}
@@ -20,4 +20,11 @@ prototype(Neos.NeosIo:Reference.List.Item) < prototype(TYPO3.TypoScript:Template
 	image = ${q(node).property('image')}
 	url = ${q(node).property('url')}
 	datePublished = ${q(node).property('datePublished')}
+	launchDate = ${q(node).property('launchDate')}
+	projectVolume = ${q(node).property('projectVolume')} {
+		@process {
+			isKnown = ${value > 1 ? value : false}
+		}
+	}
+	projectType = ${q(q(node).property('projectType')).property('title')}
 }

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/TypoScript/NodeTypes/Reference.List.ts2
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/TypoScript/NodeTypes/Reference.List.ts2
@@ -12,6 +12,14 @@ prototype(Neos.NeosIo:Reference.List) < prototype(TYPO3.Neos:Content) {
 			@process.nodeType >
 		}
 	}
+
+	@cache {
+		mode = 'cached'
+		entryTags {
+			self = ${'Node_' + node.identifier}
+			reference = 'NodeType_Neos.NeosIo:Reference'
+		}
+    }
 }
 
 prototype(Neos.NeosIo:Reference.List.Item) < prototype(TYPO3.TypoScript:Template) {

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/TypoScript/NodeTypes/Reference.List.ts2
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/TypoScript/NodeTypes/Reference.List.ts2
@@ -1,0 +1,23 @@
+prototype(Neos.NeosIo:Reference.List) < prototype(TYPO3.Neos:Content) {
+	references = TYPO3.TypoScript:Collection {
+		collection = ${Search.query(site).nodeType('Neos.NeosIo:Reference').sortDesc('datePublished').execute()}
+		itemName = 'node'
+		itemRenderer = Neos.NeosIo:Reference.List.Item
+	}
+
+	attributes {
+		class = TYPO3.TypoScript:RawArray {
+			list = 'reference-list'
+			grid = 'g'
+			@process.nodeType >
+		}
+	}
+}
+
+prototype(Neos.NeosIo:Reference.List.Item) < prototype(TYPO3.TypoScript:Template) {
+	templatePath = 'resource://Neos.NeosIo/Private/Templates/NodeTypes/Reference.List.Item.html'
+	title = ${q(node).property('title')}
+	image = ${q(node).property('image')}
+	url = ${q(node).property('url')}
+	datePublished = ${q(node).property('datePublished')}
+}

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/TypoScript/NodeTypes/Reference.ShowCase.ts2
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/TypoScript/NodeTypes/Reference.ShowCase.ts2
@@ -1,0 +1,22 @@
+/**
+* NodeTypes around Show Cases
+*/
+
+
+prototype(Neos.NeosIo:Reference.ShowCase.Document) < prototype(Neos.NeosIo:Reference.Document) {
+	body {
+		content {
+			main = Neos.NeosIo:Reference.ShowCase
+		}
+	}
+
+	@cache {
+		entryTags {
+			reference = 'NodeTypes_Neos.NeosIo:Reference'
+		}
+	}
+}
+
+prototype(Neos.NeosIo:Reference.ShowCase) < prototype(Neos.NeosIo:Reference) {
+	templatePath = 'resource://Neos.NeosIo/Private/Templates/NodeTypes/Reference.ShowCase.html'
+}

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/TypoScript/NodeTypes/Reference.ShowCase.ts2
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/TypoScript/NodeTypes/Reference.ShowCase.ts2
@@ -19,4 +19,10 @@ prototype(Neos.NeosIo:Reference.ShowCase.Document) < prototype(Neos.NeosIo:Refer
 
 prototype(Neos.NeosIo:Reference.ShowCase) < prototype(Neos.NeosIo:Reference) {
 	templatePath = 'resource://Neos.NeosIo/Private/Templates/NodeTypes/Reference.ShowCase.html'
+	projectVolume = ${q(node).property('projectVolume')} {
+		@process {
+			isKnown = ${value > 1 ? value : false}
+		}
+	}
+	projectType = ${q(q(node).property('projectType')).property('title')}
 }

--- a/Packages/Sites/Neos.NeosIo/Resources/Public/Styles/Main.css
+++ b/Packages/Sites/Neos.NeosIo/Resources/Public/Styles/Main.css
@@ -531,7 +531,6 @@ input::-moz-focus-inner {
 .u-textBreak {
   word-wrap: break-word;
   -webkit-hyphens: auto;
-     -moz-hyphens: auto;
       -ms-hyphens: auto;
           hyphens: auto; }
 
@@ -1910,7 +1909,6 @@ dl {
   text-align: right;
   word-wrap: break-word;
   -webkit-hyphens: auto;
-     -moz-hyphens: auto;
       -ms-hyphens: auto;
           hyphens: auto; }
 
@@ -2066,6 +2064,18 @@ sup {
 
 sub {
   bottom: -0.25em; }
+
+/**
+ * Meta element:
+ * F.e. footer-like meta information below something with smaller and lighter text
+ *
+ *     @example
+ *     p.meta This is a simple meta data line
+ *
+ */
+.meta {
+  font-size: 14px;
+  color: #898d99; }
 
 /**
  * Table grid:
@@ -2901,6 +2911,34 @@ sub {
 
 .fundingBadges__singleElement--isInactive {
   opacity: 0.5; }
+
+/**
+ * References:
+ * Layout for show cases
+ */
+.references__list .references__item:nth-child(odd) {
+  clear: both; }
+
+.references__list .imageTeaser {
+  min-height: 250px; }
+
+.references__list .references__data {
+  font-size: 14px;
+  color: #898d99;
+  padding-top: 4px; }
+  .references__list .references__data,
+  .references__list .references__data h1, .references__list .references__data h2, .references__list .references__data h3,
+  .references__list .references__data h4, .references__list .references__data h5, .references__list .references__data h6 {
+    color: white; }
+  .references__list .references__data .btn--solidBright {
+    color: #656a71; }
+  .references__list .references__data span {
+    display: block;
+    padding-right: 1em;
+    white-space: nowrap; }
+    @media screen and (min-width: 400px) {
+      .references__list .references__data span {
+        display: inline-block; } }
 
 .siteHeader {
   position: fixed;


### PR DESCRIPTION
Includes show cases based on the old website but enhanced with detail information (launch date, project type and project volume).
Includes styling based on the case study teaser element (image teaser).
Includes a basic template for a show case detail view which is for the moment only used in the backend as we currently won't have public detail pages.
Refactors image teaser to enable reusable code.
Adds new atom 'meta' to be used as style element.

To test the show cases create a show case document node and a reference type node. Fill in the properties of the show case and create a page where you add a 'Reference List' content element.
(Note: Currently all show cases will be shown. The queries to restrict the list to a certain reference type or to hide certain reference types are not ready.