### PR TITLE
BUGFIX: Filter invalid documents in sitemap

### DIFF
--- a/Packages/Sites/Neos.NeosIo/Resources/Private/TypoScript/Documents/XmlSitemap.ts2
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/TypoScript/Documents/XmlSitemap.ts2
@@ -1,0 +1,11 @@
+prototype(TYPO3.Neos.Seo:XmlSitemap) {
+    body {
+        filter = TYPO3.TypoScript:RawArray {
+            documents = 'TYPO3.Neos:Document'
+            excludeSpacers = '!Neos.NeosIo:SpacerPage'
+            excludeReferences = '!Neos.NeosIo:Reference'
+            excludeFooterContainers = '!Neos.NeosIo:FooterContainer'
+            @process.createFilter = ${Array.join(value, ',')}
+        }
+    }
+}


### PR DESCRIPTION
There are some document types in the site which are not meant for viewing directly.

Resolves: #123