### PR TITLE
TASK: Tweak Showcases filter

### DIFF
--- a/Packages/Sites/Neos.NeosIo/Resources/Private/TypoScript/NodeTypes/Reference.List.ts2
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/TypoScript/NodeTypes/Reference.List.ts2
@@ -12,8 +12,8 @@ prototype(Neos.NeosIo:Reference.List) < prototype(TYPO3.Neos:Content) {
 	}
 
 	paginationConfiguration = TYPO3.TypoScript:RawArray {
-		itemsPerPage = 25
-		insertAbove = ${true}
+		itemsPerPage = 24
+		insertAbove = ${false}
 		insertBelow = ${true}
 		maximumNumberOfLinks = 3
 	}


### PR DESCRIPTION
* Display 24 items per page (looks nicer with the two column
  default layout)
* Hide pagination navigation above filter result

Related: #126