### PR TITLE
BUGFIX: Add size to lazy loaded images

### DIFF
--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/FusionObjects/PostShort.html
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/FusionObjects/PostShort.html
@@ -12,6 +12,8 @@
                             alt="{title -> f:format.stripTags()}"
                             class="media__img media__img--scaled u-mb1/1"
                             src="{media:uri.image(image: image, width: 1000, height: 250, allowCropping: true)}"
+                            width="{image.width}"
+                            height="{image.height}"
                             srcset="
                                     {media:uri.image(image: image, width: 1000, height: 250, allowCropping: true)} 1920w,
                                     {media:uri.image(image: image, width: 700, height: 175, allowCropping: true)} 1280w,
@@ -24,6 +26,8 @@
                             alt="{title -> f:format.stripTags()}"
                             class="media__img media__img--scaled u-mb1/1"
                             src="{f:uri.resource(package: 'Neos.NeosIo', path: 'Images/Loader.svg')}"
+                            width="{image.width}"
+                            height="{image.height}"
                             data-image-normal="{media:uri.image(image: image, width: 1000, height: 250, allowCropping: true)}"
                             data-image-srcset="
                                     {media:uri.image(image: image, width: 1000, height: 250, allowCropping: true)} 1920w,

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Partials/LazyLoadImage.html
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Partials/LazyLoadImage.html
@@ -3,11 +3,15 @@
 <f:if condition="{neos:rendering.inBackend()}">
 	<f:then>
 		<img src="{media:uri.image(image: image, width: width, maximumWidth: maximumWidth, height: height, maximumHeight: maximumHeight, allowUpScaling: allowUpScaling, allowCropping: allowCropping)}"
+			 width="{maximumWidth -> f:format.number(decimals: 0)}"
+			 height="{maximumHeight -> f:format.number(decimals: 0)}"
 			 alt="{alternativeText}" title="{title}" class="{class}"/>
 	</f:then>
 	<f:else>
 		<img src="{f:uri.resource(package: 'Neos.NeosIo', path: 'Images/Loader.svg')}"
 			 alt="{alternativeText}" title="{title}" class="{class}"
+			 width="{maximumWidth -> f:format.number(decimals: 0)}"
+			 height="{maximumHeight -> f:format.number(decimals: 0)}"
 			 data-image-normal="{media:uri.image(image: image, width: width, maximumWidth: maximumWidth, height: height, maximumHeight: maximumHeight, allowUpScaling: allowUpScaling, allowCropping: allowCropping)}"/>
 	</f:else>
 </f:if>


### PR DESCRIPTION
Without the width and height attributes
there can be rendering errors in several
browsers.

Resolves: #150