### PR TITLE
TASK: Sort Show Cases by publishing date by default

### DIFF
--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Fusion/NodeTypes/Reference.List.fusion
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Fusion/NodeTypes/Reference.List.fusion
@@ -1,5 +1,5 @@
 prototype(Neos.NeosIo:Reference.List) < prototype(Neos.Neos:Content) {
-    orderOptions = ${{featured: 'Featured', datePublished: 'Publish date', launchDate: 'Launch date', projectVolume: 'Project volume'}}
+    orderOptions = ${{datePublished: 'Publish date', launchDate: 'Launch date', projectVolume: 'Project volume', featured: 'Featured'}}
     defaultOrder = ${Array.keys(this.orderOptions)[0]}
 
 	projectVolumeOptions = ${{'5': '< 100 h', '10': '100 - 499h', '15': '500 - 999h', '20': '1000 - 3000h', '25': '> 3000h'}}

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Fusion/NodeTypes/Reference.List.fusion
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Fusion/NodeTypes/Reference.List.fusion
@@ -1,11 +1,11 @@
 prototype(Neos.NeosIo:Reference.List) < prototype(Neos.Neos:Content) {
-    orderOptions = ${{datePublished: 'Publish date', launchDate: 'Launch date', projectVolume: 'Project volume', featured: 'Featured'}}
+    orderOptions = ${{featured: 'Featured', datePublished: 'Publish date', launchDate: 'Launch date', projectVolume: 'Project volume'}}
     defaultOrder = ${Array.keys(this.orderOptions)[0]}
 
-	projectVolumeOptions = ${{'5': '< 100 h', '10': '100 - 499h', '15': '500 - 999h', '20': '1000 - 3000h', '25': '> 3000h'}}
+    projectVolumeOptions = ${{'5': '< 100 h', '10': '100 - 499h', '15': '500 - 999h', '20': '1000 - 3000h', '25': '> 3000h'}}
 
-	referenceType = ${request.arguments.referenceType}
-	projectVolume = ${request.arguments.projectVolume}
+    referenceType = ${request.arguments.referenceType}
+    projectVolume = ${request.arguments.projectVolume}
     searchTerm = ${request.arguments.search}
     order = ${Array.indexOf(Array.keys(this.orderOptions), request.arguments.order) != -1 ? request.arguments.order : this.defaultOrder}
     limit = ${request.arguments.limit}
@@ -13,7 +13,7 @@ prototype(Neos.NeosIo:Reference.List) < prototype(Neos.Neos:Content) {
     @context {
         defaultOrder = ${this.defaultOrder}
         referenceType = ${this.referenceType}
-		projectVolume = ${this.projectVolume}
+        projectVolume = ${this.projectVolume}
         searchTerm = ${this.searchTerm}
         order = ${this.order}
         limit = ${this.limit}
@@ -32,8 +32,14 @@ prototype(Neos.NeosIo:Reference.List) < prototype(Neos.Neos:Content) {
     references.@process {
         fulltext = ${String.isBlank(searchTerm) ? value : value.fulltext(searchTerm + '*')}
         referenceType = ${String.isBlank(referenceType) ? value : value.exactMatch('projectType', referenceType)}
-		projectVolume = ${String.isBlank(projectVolume) ? value : value.exactMatch('projectVolume', projectVolume)}
+        projectVolume = ${String.isBlank(projectVolume) ? value : value.exactMatch('projectVolume', projectVolume)}
+
+        // Do the ordering as selected by the user or use default ordering if nothing is selected
         order = ${String.isBlank(order) ? value.sortDesc(defaultOrder) : value.sortDesc(order)}
+
+        // Always have a secondary sort by publish date
+        orderByPublishDate = ${value.sortDesc('datePublished')}
+
         limit = ${String.isBlank(limit) ? value.limit(20) : value.limit(limit)}
     }
 


### PR DESCRIPTION
Since cb61d57 Show Cases can be marged "featured" but right now there aren't
any featured Show Cases so I suggest to order the references by publication date as before.

IMO Featured should not be a "orderOption" but a separate filter once we have some featured Show Cases