### PR TITLE
TASK: Allow reader mode for blog posts

### DIFF
--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Post.html
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Post.html
@@ -1,62 +1,67 @@
 {namespace neos=Neos\Neos\ViewHelpers}{namespace media=Neos\Media\ViewHelpers}{namespace ts=Neos\Fusion\ViewHelpers}
+<article>
+	<header>
+		<neos:contentElement.wrap node="{node}">
+			<neos:contentElement.editable property="title" tag="h1" additionalAttributes="{itemprop: 'title'}" class="u-alignCenter" />
 
-<neos:contentElement.wrap node="{node}">
-	<neos:contentElement.editable property="title" tag="h1" additionalAttributes="{itemprop: 'title'}" class="u-alignCenter" />
-
-	<neos:contentElement.editable property="summary" tag="p" class="u-alignCenter" additionalAttributes="{itemprop: 'description'}"/>
-	<p class="u-alignCenter u-microCopy">
-		<time datetime="{datePublished -> f:format.date(format: 'c')}" itemprop="datePublished">{datePublished
-			-> f:format.date(localeFormatType: 'date', forceLocale: true)}
-		</time>
-		<f:if condition="{author}">
-			– Written by
-			<span itemprop="author" itemscope="" itemtype="https://schema.org/Person"><span itemprop="name">{author}</span></span>
-		</f:if>
-		<f:if condition="{image}">
-			<meta itemprop="image" content="{media:uri.image(image: image, maximumWidth: 720, maximumHeight: 500, allowCropping: 1, allowUpScaling: 1)}"/>
-		</f:if>
-	</p>
-
-	<hr />
-
-</neos:contentElement.wrap>
-
-<main itemprop="articleBody">
-	{content -> f:format.raw()}
-</main>
-
-<hr />
-
-<section class="u-mt1/1">
-
-	<f:if condition="{relatedDocuments}">
-		<div class="u-pt1/1">
-			<h3>Related</h3>
-			<ul class="nav nav--stacked u-mb1/2">
-				<f:for each="{relatedDocuments}" as="relatedDocument">
-					<li class="u-mb1/2">
-						<neos:link.node node="{relatedDocument}"/>
-					</li>
-				</f:for>
-			</ul>
-		</div>
-	</f:if>
-
-	<div class="u-pt1/1">
-		<h3>Latest Posts</h3>
-		<ul class="nav nav--stacked u-mb1/2">
-			<f:for each="{latest}" as="post">
-				<f:if condition="{post} != {node}">
-					<li class="u-mb1/2" title="{post.properties.summary -> f:format.stripTags()}">
-						<div class="h5">
-							{post.properties.datePublished -> f:format.date(localeFormatType: 'date', forceLocale: true)} -
-							<neos:link.node node="{post}"/>
-						</div>
-					</li>
+			<neos:contentElement.editable property="summary" tag="p" class="u-alignCenter" additionalAttributes="{itemprop: 'description'}"/>
+			<p class="u-alignCenter u-microCopy">
+				<time datetime="{datePublished -> f:format.date(format: 'c')}" itemprop="datePublished">{datePublished
+					-> f:format.date(localeFormatType: 'date', forceLocale: true)}
+				</time>
+				<f:if condition="{author}">
+					– Written by
+					<span itemprop="author" itemscope="" itemtype="https://schema.org/Person"><span itemprop="name">{author}</span></span>
 				</f:if>
-			</f:for>
-		</ul>
+				<f:if condition="{image}">
+					<meta itemprop="image" content="{media:uri.image(image: image, maximumWidth: 720, maximumHeight: 500, allowCropping: 1, allowUpScaling: 1)}"/>
+				</f:if>
+			</p>
 
-		{backToListButton -> f:format.raw()}
-	</div>
-</section>
+			<hr />
+
+		</neos:contentElement.wrap>
+	</header>
+
+	<main itemprop="articleBody">
+		{content -> f:format.raw()}
+	</main>
+
+	<footer>
+		<hr />
+
+		<section class="u-mt1/1">
+
+			<f:if condition="{relatedDocuments}">
+				<div class="u-pt1/1">
+					<h3>Related</h3>
+					<ul class="nav nav--stacked u-mb1/2">
+						<f:for each="{relatedDocuments}" as="relatedDocument">
+							<li class="u-mb1/2">
+								<neos:link.node node="{relatedDocument}"/>
+							</li>
+						</f:for>
+					</ul>
+				</div>
+			</f:if>
+
+			<div class="u-pt1/1">
+				<h3>Latest Posts</h3>
+				<ul class="nav nav--stacked u-mb1/2">
+					<f:for each="{latest}" as="post">
+						<f:if condition="{post} != {node}">
+							<li class="u-mb1/2" title="{post.properties.summary -> f:format.stripTags()}">
+								<div class="h5">
+									{post.properties.datePublished -> f:format.date(localeFormatType: 'date', forceLocale: true)} -
+									<neos:link.node node="{post}"/>
+								</div>
+							</li>
+						</f:if>
+					</f:for>
+				</ul>
+
+				{backToListButton -> f:format.raw()}
+			</div>
+		</section>
+	</footer>
+</article>


### PR DESCRIPTION
This change adds the necessary semantic html5
tags to blog posts so the reader mode of RSS
readers and browsers can extract the content.

Resolves: #187