### PR TITLE
BUGFIX: Circumvent event page site rewrite

### DIFF
--- a/Packages/Application/Neos.NeosIo.Event/Resources/Private/Fusion/Root.fusion
+++ b/Packages/Application/Neos.NeosIo.Event/Resources/Private/Fusion/Root.fusion
@@ -1,4 +1,5 @@
 root {
+	@context.rootSite = ${site}
 	@context.site = ${q(node).closest('[instanceof Neos.NeosIo.Event:Event]').get(0) ? q(node).closest('[instanceof Neos.NeosIo.Event:Event]').get(0) : site}
 }
 

--- a/Packages/Sites/Neos.NeosIo/Resources/Private/Fusion/FusionObjects/MetaTags.fusion
+++ b/Packages/Sites/Neos.NeosIo/Resources/Private/Fusion/FusionObjects/MetaTags.fusion
@@ -1,8 +1,8 @@
 prototype(Neos.NeosIo:MetaTags) < prototype(Neos.Fusion:Component) {
-    showSmartAppBanner = ${q(site).property('showSmartAppBanner')}
-    iOSAppId = ${q(site).property('iOSAppId')}
+    showSmartAppBanner = ${q(rootSite || site).property('showSmartAppBanner')}
+    iOSAppId = ${q(rootSite || site).property('iOSAppId')}
     rssUri = Neos.Neos:NodeUri {
-        node = ${site}
+        node = ${rootSite || site}
         absolute = true
         @process.append = ${value + 'rss.xml'}
     }


### PR DESCRIPTION
The metags couldn’t access the root site
as the events code changes the site variable.