### PR TITLE
BUGFIX: fix ContentImageMixin having no type

### DIFF
--- a/src/Neos.NeosIo/Configuration/NodeTypes.yaml
+++ b/src/Neos.NeosIo/Configuration/NodeTypes.yaml
@@ -47,7 +47,9 @@
 'Neos.NodeTypes:ContentImageMixin':
   properties:
     openInNewTab:
+      type: boolean
       ui:
+        label: 'Open in new Tab'
         inspector:
           group: image
 


### PR DESCRIPTION
added missing type for Neos.NodeTypes:ContentImageMixin that lead to a rendering error in the inspector