### PR TITLE
TASK: allow custom height to be set on images

### DIFF
--- a/src/Neos.NeosIo/Configuration/NodeTypes.yaml
+++ b/src/Neos.NeosIo/Configuration/NodeTypes.yaml
@@ -52,6 +52,15 @@
         label: 'Open in new Tab'
         inspector:
           group: image
+    customHeight:
+      type: integer
+      defaultValue: ''
+      ui:
+        reloadIfChanged: true
+        label: 'Height in px'
+        inspector:
+          group: image
+
 
 
 'Neos.NodeTypes:Text':

--- a/src/Neos.NeosIo/Resources/Private/Fusion/NodeTypes/Image.fusion
+++ b/src/Neos.NeosIo/Resources/Private/Fusion/NodeTypes/Image.fusion
@@ -11,4 +11,7 @@ prototype(Neos.NodeTypes:Image) {
 
     imageClassName.@process.addImageStyle = ${value + ' ' + q(node).property('imageStyle')}
     imageClassName.@process.addImageStyle.@if.isSet = ${!String.isBlank(q(node).property('imageStyle'))}
+
+    maxheight = ${q(node).property('customHeight') ? q(node).property('customHeight') : this.maximumHeight}
+    maxWidth = ${q(node).property('customHeight') ? null : this.maximumWidth}
 }

--- a/src/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Partials/Image.html
+++ b/src/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Partials/Image.html
@@ -5,7 +5,7 @@
 	<f:then>
 		<io:link.external uri="{link}" openInNewTab="{openInNewTab}" noLinkWhen="{neos:rendering.inBackend()}">
 			<f:render partial="LazyLoadImage"
-					  arguments="{title: title, alternativeText: alternativeText, image: image, width: width, maximumWidth: maximumWidth, height: height, maximumHeight: maximumHeight, allowUpScaling: allowUpScaling}"/>
+					  arguments="{title: title, alternativeText: alternativeText, image: image, width: width, maximumWidth: maxWidth, height: height, maximumHeight: maxheight, allowUpScaling: allowUpScaling}"/>
 		</io:link.external>
 	</f:then>
 	<f:else>

--- a/src/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Partials/LazyLoadImage.html
+++ b/src/Neos.NeosIo/Resources/Private/Templates/NodeTypes/Partials/LazyLoadImage.html
@@ -3,15 +3,15 @@
 <f:if condition="{neos:rendering.inBackend()}">
 	<f:then>
 		<img src="{media:uri.image(image: image, width: width, maximumWidth: maximumWidth, height: height, maximumHeight: maximumHeight, allowUpScaling: allowUpScaling, allowCropping: allowCropping)}"
-			 width="{maximumWidth -> f:format.number(decimals: 0, thousandsSeparator: '', decimalSeparator: '')}"
-			 height="{maximumHeight -> f:format.number(decimals: 0, thousandsSeparator: '', decimalSeparator: '')}"
+			 width="{maximumWidth}"
+			 height="{maximumHeight}"
 			 alt="{alternativeText}" title="{title}" class="{class}"/>
 	</f:then>
 	<f:else>
 		<img src="{f:uri.resource(package: 'Neos.NeosIo', path: 'Images/Loader.svg')}"
 			 alt="{alternativeText}" title="{title}" class="{class}"
-			 width="{maximumWidth -> f:format.number(decimals: 0, thousandsSeparator: '', decimalSeparator: '')}"
-			 height="{maximumHeight -> f:format.number(decimals: 0, thousandsSeparator: '', decimalSeparator: '')}"
+			 width="{maximumWidth}"
+			 height="{maximumHeight}"
 			 data-image-normal="{media:uri.image(image: image, width: width, maximumWidth: maximumWidth, height: height, maximumHeight: maximumHeight, allowUpScaling: allowUpScaling, allowCropping: allowCropping)}"/>
 	</f:else>
 </f:if>


### PR DESCRIPTION
For this to work we had to change the LazyLoadImage partial, disabling
the automatic formatting of the maximumWidth and -Height values to a number
as this made it impossible to pass "null", which we need to disable rendering
of the width attribute, so the media:uri.image view helper does not default
back to maximumWidth, effectively stretching an image with a set height
instead of applying width: auto