### PR TITLE
BUGFIX: ImageTeaser was missing default properties

### DIFF
--- a/src/Neos.NeosConIo/Resources/Private/Fusion/Documents/Speaker.fusion
+++ b/src/Neos.NeosConIo/Resources/Private/Fusion/Documents/Speaker.fusion
@@ -7,7 +7,7 @@ prototype(Neos.NeosConIo:Speaker.Document) < prototype(Neos.NeosIo:DefaultPage) 
 
             title = ${q(featuredTalkNode).property('title')}
             image = ${q(featuredTalkNode).property('thumbnail')}
-            imageUrl = ${(q(featuredTalkNode).property('video') && !q(featuredTalkNode).property('thumbnail')) ? "https://img.youtube.com/vi/" + q(featuredTalkNode).property('video') + "/maxresdefault.jpg" : null}
+            fallbackImageUrl = ${(q(featuredTalkNode).property('video') && !q(featuredTalkNode).property('thumbnail')) ? "https://img.youtube.com/vi/" + q(featuredTalkNode).property('video') + "/maxresdefault.jpg" : null}
             text = ${q(featuredTalkNode).property('text')}
             className = 'imageTeaser--featuredTalk'
             link = Neos.Neos:NodeUri {
@@ -32,7 +32,7 @@ prototype(Neos.NeosConIo:Speaker.Document) < prototype(Neos.NeosIo:DefaultPage) 
                     // node is the talk here
                     title = ${node.properties.title}
                     image = ${node.properties.thumbnail}
-                    imageUrl = ${(node.properties.video && !node.properties.thumbnail) ? "https://img.youtube.com/vi/" + node.properties.video + "/maxresdefault.jpg" : null}
+                    fallbackImageUrl = ${(node.properties.video && !node.properties.thumbnail) ? "https://img.youtube.com/vi/" + node.properties.video + "/maxresdefault.jpg" : null}
                     text = ${node.properties.text}
                     className = 'imageTeaser--relatedTalk'
                     link = Neos.Neos:NodeUri {

--- a/src/Neos.NeosConIo/Resources/Private/Fusion/FusionObjects/TalkList.fusion
+++ b/src/Neos.NeosConIo/Resources/Private/Fusion/FusionObjects/TalkList.fusion
@@ -12,7 +12,7 @@ prototype(Neos.NeosConIo:TalkList) < prototype(Neos.Fusion:Collection) {
             // node is the talk here
             title = ${node.properties.title}
             image = ${node.properties.thumbnail}
-            imageUrl = ${(node.properties.video && !node.properties.thumbnail) ? "https://img.youtube.com/vi/" + node.properties.video + "/maxresdefault.jpg" : null}
+            fallbackImageUrl = ${(node.properties.video && !node.properties.thumbnail) ? "https://img.youtube.com/vi/" + node.properties.video + "/maxresdefault.jpg" : null}
             text = ${node.properties.text}
             className = 'imageTeaser--relatedTalk'
             link = Neos.Neos:NodeUri {

--- a/src/Neos.NeosIo/Resources/Private/Fusion/NodeTypes/ImageTeaser.fusion
+++ b/src/Neos.NeosIo/Resources/Private/Fusion/NodeTypes/ImageTeaser.fusion
@@ -3,12 +3,10 @@ prototype(Neos.NeosIo:ImageTeaser) < prototype(Neos.Neos:Content) {
         absolute = true
     }
 
-    title = null
-    // is an asset. Either image or imageUrl must be specified.
-    image = null
-    // is an URL. Either image or imageUrl must be specified.
-    imageUrl = null
-    text = null
+    title = ${q(node).property('title')}
+    image = ${q(node).property('image')}
+    text = ${q(node).property('text')}
+    fallbackImageUrl = null
     className = null
 
     sectionName = 'main'

--- a/src/Neos.NeosIo/Resources/Private/Templates/NodeTypes/ImageTeaser.html
+++ b/src/Neos.NeosIo/Resources/Private/Templates/NodeTypes/ImageTeaser.html
@@ -24,9 +24,9 @@
 					  arguments="{class: 'imageTeaser__image', title: title, alternativeText: alternativeText, image: image, maximumWidth: '700c', maximumHeight: '450c', allowUpScaling: allowUpScaling}"/>
 		</f:then>
 		<f:else>
-			<f:if condition="{imageUrl}">
+			<f:if condition="{fallbackImageUrl}">
 				<f:then>
-					<img src="{imageUrl}"
+					<img src="{fallbackImageUrl}"
 						 alt="{alternativeText}" title="{title}" class="{class}"
 						 />
 				</f:then>


### PR DESCRIPTION
Also renames imageUrl to fallbackImageUrl to make
it clear what it does.