### PR TITLE
BUGFIX: Load matching styles for pages

### DIFF
--- a/DistributionPackages/Neos.MarketPlace/Resources/Private/Fusion/Documents/DefaultPage.fusion
+++ b/DistributionPackages/Neos.MarketPlace/Resources/Private/Fusion/Documents/DefaultPage.fusion
@@ -1,12 +1,12 @@
-prototype(Neos.NeosIo:PageStyles) {
-    neosMarketPlace = Neos.Fusion:Component {
-        @position = 'after main'
-        renderer = afx`
-            <link rel="stylesheet" @children="attributes.href">
+prototype(Neos.MarketPlace:DefaultPage) < prototype(Neos.NeosIo:DefaultPage) {
+    prototype(Neos.NeosIo:PageStyles) {
+        neosMarketPlace = Neos.Fusion:Component {
+            @position = 'after main'
+            renderer = afx`
+                <link rel="stylesheet" @children="attributes.href">
                 <Neos.Fusion:ResourceUri path="resource://Neos.MarketPlace/Public/Styles/Main.css"/>
-            </link>
-        `
+                </link>
+            `
+        }
     }
 }
-
-prototype(Neos.MarketPlace:DefaultPage) < prototype(Neos.NeosIo:DefaultPage)

--- a/DistributionPackages/Neos.NeosConIo/Resources/Private/Fusion/Documents/DefaultPage.fusion
+++ b/DistributionPackages/Neos.NeosConIo/Resources/Private/Fusion/Documents/DefaultPage.fusion
@@ -1,5 +1,12 @@
-prototype(Neos.NeosIo:DefaultPage) {
-    head.stylesheets.main.uri = 'resource://Neos.NeosConIo/Public/Styles/Main.css'
+prototype(Neos.NeosIo:PageStyles) {
+    neosConIo = Neos.Fusion:Component {
+        @position = 'after main'
+        renderer = afx`
+            <link rel="stylesheet" @children="attributes.href">
+                <Neos.Fusion:ResourceUri path="resource://Neos.NeosConIo/Public/Styles/Main.css"/>
+            </link>
+        `
+    }
 }
 
 prototype(Neos.NeosIo:DefaultPage.Menu) {

--- a/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/Components/PageStyles.fusion
+++ b/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/Components/PageStyles.fusion
@@ -1,7 +1,7 @@
 prototype(Neos.NeosIo:PageStyles) < prototype(Neos.Fusion:Array) {
     main = afx`
         <link rel="stylesheet" @children="attributes.href">
-        <Neos.Fusion:ResourceUri path="resource://Neos.NeosIo/Public/Styles/Main.css"/>
+            <Neos.Fusion:ResourceUri path="resource://Neos.NeosIo/Public/Styles/Main.css"/>
         </link>
     `
 


### PR DESCRIPTION
During the sprint refactoring the includes were mixed up which cause css issues on neoscon.io