### PR TITLE
Fix: Don`t show sum for badgeType event organizer

### DIFF
--- a/DistributionPackages/Neos.NeosIo/Resources/Private/Templates/NodeTypes/FundingBadges.html
+++ b/DistributionPackages/Neos.NeosIo/Resources/Private/Templates/NodeTypes/FundingBadges.html
@@ -45,7 +45,7 @@
 			   <ul>
 					<f:for each="{customer.badges}" as="badge">
 						<li class="funding-badge--item">
-							<f:if condition="{badge.customerSum} > 0 && {badge.badgeCategory} != 'Active Team Member Employers'">
+							<f:if condition="{badge.customerSum} > 0 && {badge.badgeCategory} != 'Active Team Member Employers' && {badge.badgeCategory} != 'Sprint organizers & supporters'">
 								<strong class="funding-badge--customer-sum">
 									{badge.customerSum -> f:format.currency(currencySign: '€')}
 								</strong>


### PR DESCRIPTION
The event organizers badges show the sum value of the last purchased badge with an amount.
This is an issue in the funding API, but we can prevent showing the sum value.