### PR TITLE
BUGFIX: Fix relative url paths in CSS

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -102,6 +102,7 @@ function config(
                         {
                             loader: 'css-loader',
                             options: {
+                                url: false,
                                 sourceMap: isInlineAsset ? false : hasSourceMap,
                                 importLoaders: 2
                             }


### PR DESCRIPTION
If you don't use the `resolve` function from `postcss-assets`, it was not possible the include `url` in your CSS. With this change `url()` in CSS doesn't get parsed. Read more about this option here:
https://github.com/webpack-contrib/css-loader#url

## How to test it
Add a CSS rule with a background-image with `url`. Before it tries to rewrite it, with this change it leaves it as it is.