### PR TITLE
TASK: Add maximumLifetime to the cache of a service provider page

### DIFF
--- a/DistributionPackages/Neos.NeosIo.ServiceOfferings/Resources/Private/Fusion/Documents/ServiceProvider.fusion
+++ b/DistributionPackages/Neos.NeosIo.ServiceOfferings/Resources/Private/Fusion/Documents/ServiceProvider.fusion
@@ -117,4 +117,8 @@ prototype(Neos.NeosIo.ServiceOfferings:Document.ServiceProvider) < prototype(Neo
             }
         }
     }
+
+    @cache {
+        maximumLifetime = 86400
+    }
 }


### PR DESCRIPTION
This makes sure that the data from the funding platform is updated regulary without the node itself changing.

The service provider collection does not get the cache tag now as it does not display data from the funding platform and only changes once the nodes below change wich is covered by the descendentOf cache tag.