### PR TITLE
FEATURE: Make case study page work as landing page

### DIFF
--- a/DistributionPackages/Neos.NeosIo/Configuration/NodeTypes.Reference.CaseStudy.yaml
+++ b/DistributionPackages/Neos.NeosIo/Configuration/NodeTypes.Reference.CaseStudy.yaml
@@ -1,8 +1,6 @@
 'Neos.NeosIo:Reference.CaseStudy':
   superTypes:
-    'Neos.Seo:NoindexMixin': false
-    'Neos.NodeTypes:Page': true
-    'Neos.NeosIo:KeyVisualMixin': true
+    'Neos.NeosIo:LandingPage': true
   ui:
     label: 'Case Study'
-    icon: icon-globe
+    icon: eye

--- a/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/Documents/Page/CaseStudy.fusion
+++ b/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/Documents/Page/CaseStudy.fusion
@@ -1,0 +1,1 @@
+prototype(Neos.NeosIo:Reference.CaseStudy) < prototype(Neos.NeosIo:LandingPage)


### PR DESCRIPTION
Previously the case study page was not used as it didn’t
look and behave like the landing page.

But we need the case study page type to reference
them in the providers list.