### PR TITLE
BUGFIX: Pass CSS Comments also to PostCSS

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -124,6 +124,7 @@ function config(
                                 // absolute paths for SCSS
                                 sassOptions: {
                                     importer: GlobImporter(),
+                                    outputStyle: 'nested',
                                     includePaths: includePaths
                                 }
                             }


### PR DESCRIPTION
Without this fix, all CSS comments who can also be commands for PostCSS will be removed.