### PR TITLE
BUGFIX: Searching for " does not break search

### DIFF
--- a/DistributionPackages/Neos.MarketPlace/Resources/Private/Fusion/FusionObjects/Search.fusion
+++ b/DistributionPackages/Neos.MarketPlace/Resources/Private/Fusion/FusionObjects/Search.fusion
@@ -43,7 +43,7 @@ prototype(Neos.MarketPlace:Search) < prototype(Flowpack.SearchPlugin:Search) {
 
     query.@process.nodeType = ${value.nodeType('Neos.MarketPlace:Package')}
 
-    query.@process.fulltext = ${this.hasSearchQuery ? value.fulltext('*' + this.searchTerm + '*') : value}
+    query.@process.fulltext = ${this.hasSearchQuery ? value.fulltext('*' + String.replace(this.searchTerm, '"', '') + '*') : value}
 
     query.@process.sort = ${this.hasSearchQuery ? value : value.sortDesc('lastActivity')}
 


### PR DESCRIPTION
Right now a search for " breaks the search. This change removes " from
the search term, to fix that. As far as I found out, it is the only
character breaking the search.