### PR TITLE
FEATURE: Added dimension based 404 handling

### DIFF
--- a/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/FusionObjects/Error.fusion
+++ b/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/FusionObjects/Error.fusion
@@ -1,10 +1,16 @@
 error {
     @context.notfoundDocument = ${q(site).children('[uriPathSegment = "404"]').get(0)}
     4xx {
+        dimensions = Neos.NeosIo:ExtractDimensions
+        @context.notfoundDocument = ${q(site).context({'dimensions': this.dimensions.dimensions, 'targetDimensions': this.dimensions.targetDimensions}).children('[instanceof Neos.Neos:Document]').filter('[uriPathSegment="404"]').get(0)}
         @position = 'start'
         condition = ${statusCode >= 400 && statusCode < 500 && notfoundDocument}
         renderer = Neos.Fusion:Renderer {
-            @context.node = ${notfoundDocument}
+            @context {
+                site = ${notfoundDocument.context.currentSiteNode}
+                node = ${notfoundDocument}
+                documentNode = ${notfoundDocument}
+            }
             renderPath = '/root'
         }
     }

--- a/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/FusionObjects/Error.fusion
+++ b/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/FusionObjects/Error.fusion
@@ -2,7 +2,7 @@ error {
     @context.notfoundDocument = ${q(site).children('[uriPathSegment = "404"]').get(0)}
     4xx {
         dimensions = Neos.NeosIo:ExtractDimensions
-        @context.notfoundDocument = ${q(site).context({'dimensions': this.dimensions.dimensions, 'targetDimensions': this.dimensions.targetDimensions}).children('[instanceof Neos.Neos:Document]').filter('[uriPathSegment="404"]').get(0)}
+        @context.notfoundDocument = ${q(site).context({'dimensions': this.dimensions.dimensions, 'targetDimensions': this.dimensions.targetDimensions}).children('[instanceof Neos.Neos:Document][uriPathSegment="404"]').get(0)}
         @position = 'start'
         condition = ${statusCode >= 400 && statusCode < 500 && notfoundDocument}
         renderer = Neos.Fusion:Renderer {

--- a/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/FusionObjects/ExtractDimensions.fusion
+++ b/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/FusionObjects/ExtractDimensions.fusion
@@ -1,0 +1,32 @@
+prototype(Neos.NeosIo:ExtractDimensions) < prototype(Neos.Fusion:Value) {
+    @context{
+        languageDimension = ${Array.first(String.split(String.trim(request.httpRequest.uri.path, '/'), '/', 2))}
+        defaultPresets = Neos.Fusion:DataStructure {
+            language = ${Configuration.setting('Neos.ContentRepository.contentDimensions.language.defaultPreset')}
+        }
+    }
+    value = Neos.Fusion:Case {
+        dimensionsFound {
+            condition = ${String.isBlank(languageDimension) == false && Configuration.setting('Neos.ContentRepository.contentDimensions.language.presets.' + languageDimension + '.values')}
+            renderer = Neos.Fusion:DataStructure {
+                dimensions = Neos.Fusion:DataStructure {
+                    language = ${Configuration.setting('Neos.ContentRepository.contentDimensions.language.presets.' + languageDimension + '.values')}
+                }
+                targetDimensions = Neos.Fusion:DataStructure {
+                    language = ${languageDimension}
+                }
+            }
+        }
+        noDimensionsFound {
+            condition = true
+            renderer = Neos.Fusion:DataStructure {
+                dimensions = Neos.Fusion:DataStructure {
+                    language = ${Configuration.setting('Neos.ContentRepository.contentDimensions.language.presets.' + defaultPresets.language + '.values')}
+                }
+                targetDimensions = Neos.Fusion:DataStructure {
+                    language = ${defaultPresets.language}
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
So far 404 handling was only english. Adding german as a second language, we now
have also language based 404 handling.
Taken from here:
https://discuss.neos.io/t/native-404-handling-with-content-dimensions-multi-language-sites/4739