### PR TITLE
BUGFIX: KeyVisuals without small image are being rendered again

### DIFF
--- a/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/FusionObjects/KeyVisual/ImageRenderer.fusion
+++ b/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/FusionObjects/KeyVisual/ImageRenderer.fusion
@@ -2,7 +2,7 @@
 prototype(Neos.NeosIo:KeyVisual.ImageRenderer) < prototype(Neos.NeosIo:KeyVisual.AbstractRenderer) {
     // "props.keyVisualImage" on the right side here is set inside Neos.NeosIo:KeyVisual (as this fusion object here is the renderer inside Neos.NeosIo:KeyVisual)
     keyVisualImage = ${props.keyVisualImage}
-    keyVisualImageSmall = ${props.keyVisualImageSmall || props.keyVisualImage}
+    keyVisualImageSmall = ${props.keyVisualImageSmall}
 
     previewImageUri = Neos.Neos:ImageUri {
         asset = ${props.keyVisualImage}
@@ -41,6 +41,7 @@ prototype(Neos.NeosIo:KeyVisual.ImageRenderer) < prototype(Neos.NeosIo:KeyVisual
             allowCropping = true
 
             @process.addSrcSet = ${value + " 658w"}
+            @if.hasSmallImage = ${props.keyVisualImageSmall}
         }
     }
 }


### PR DESCRIPTION
The last change resulted in a regression that made images
disappear. This was due to a broken rendering. i took out the mobile
Image variant for now as the high res image is in an acceptable size for
mobile and does look much nicer.