### PR TITLE
Improved keyvisual font weight and added a drop-shadow

### DIFF
--- a/DistributionPackages/Neos.NeosIo/Resources/Private/Scss/Organisms/_KeyVisual.scss
+++ b/DistributionPackages/Neos.NeosIo/Resources/Private/Scss/Organisms/_KeyVisual.scss
@@ -51,7 +51,24 @@
 		transform: translateX(-50%) translateY(-50%);
 	}
 
-	.keyVisual--large & {
+  h1, h2, h3,
+  h4, h5, h6,
+  .h1, .h2, .h3,
+  .h4, .h5, .h6 {
+    font-weight: 400;
+    text-shadow: 0px 0px 3px color-adjust($base-text-color, 100%);
+  }
+
+  &.u-invertText {
+    h1, h2, h3,
+    h4, h5, h6,
+    .h1, .h2, .h3,
+    .h4, .h5, .h6 {
+      text-shadow: 0px 1px 1px $headingsColor;
+    }
+  }
+
+  .keyVisual--large & {
 		height: 70vh;
 	}
 


### PR DESCRIPTION
This makes it more visible on any background image - see examples. 
By now we only have very light text which tends to disappear on backgrounds. 
We are going to use this feature a lot more, so we need to improve readability.

![FireShot Capture 215 - Why Neos CMS_ - Neos io - neosio localbeach net](https://user-images.githubusercontent.com/4123716/89983980-eab2e400-dc78-11ea-9f2c-55908fb0d6db.png)
![FireShot Capture 218 - Why Neos CMS_ - Neos io - neosio localbeach net](https://user-images.githubusercontent.com/4123716/89983988-edadd480-dc78-11ea-8e44-0a7ef23f5d48.png)
![FireShot Capture 221 - Why Neos CMS_ - Neos io - neosio localbeach net](https://user-images.githubusercontent.com/4123716/89983999-f1d9f200-dc78-11ea-9777-909d26103814.png)

