### PR TITLE
FEATURE: Tweak Release Plan

### DIFF
--- a/DistributionPackages/Neos.NeosIo/Configuration/NodeTypes.ReleasePlan.Segment.yaml
+++ b/DistributionPackages/Neos.NeosIo/Configuration/NodeTypes.ReleasePlan.Segment.yaml
@@ -14,6 +14,8 @@
   properties:
     start:
       type: DateTime
+      options:
+        showInCreationDialog: true
       ui:
         label: 'Start date'
         reloadIfChanged: true
@@ -22,6 +24,8 @@
           editor: 'Neos.Neos/Inspector/Editors/DateTimeEditor'
     end:
       type: DateTime
+      options:
+        showInCreationDialog: true
       ui:
         label: 'End date'
         reloadIfChanged: true
@@ -30,6 +34,8 @@
           editor: 'Neos.Neos/Inspector/Editors/DateTimeEditor'
     task:
       type: string
+      options:
+        showInCreationDialog: true
       ui:
         label: 'Task name'
         help:
@@ -37,3 +43,6 @@
         reloadIfChanged: true
         inspector:
           group: 'releasePlan'
+          editor: 'Neos.Neos/Inspector/Editors/TextAreaEditor'
+          editorOptions:
+            rows: 2

--- a/DistributionPackages/Neos.NeosIo/Configuration/NodeTypes.ReleasePlan.Version.yaml
+++ b/DistributionPackages/Neos.NeosIo/Configuration/NodeTypes.ReleasePlan.Version.yaml
@@ -2,6 +2,7 @@
   superTypes:
     'Neos.Neos:Content': true
     'Neos.Neos:ContentCollection': true
+  label: "${q(node).property('version')}"
   ui:
     label: 'Release Version'
     icon: icon-calendar-week
@@ -19,6 +20,8 @@
   properties:
     version:
       type: string
+      options:
+        showInCreationDialog: true
       ui:
         label: 'Version'
         help:
@@ -26,3 +29,33 @@
         reloadIfChanged: true
         inspector:
           group: 'releasePlan'
+    releaseDate:
+      type: DateTime
+      options:
+        showInCreationDialog: true
+      ui:
+        label: 'Release date'
+        reloadIfChanged: true
+        inspector:
+          group: 'releasePlan'
+          editor: 'Neos.Neos/Inspector/Editors/DateTimeEditor'
+    activeSupportUntil:
+      type: DateTime
+      options:
+        showInCreationDialog: true
+      ui:
+        label: 'End of active support'
+        reloadIfChanged: true
+        inspector:
+          group: 'releasePlan'
+          editor: 'Neos.Neos/Inspector/Editors/DateTimeEditor'
+    endOfLife:
+      type: DateTime
+      options:
+        showInCreationDialog: true
+      ui:
+        label: 'End of life'
+        reloadIfChanged: true
+        inspector:
+          group: 'releasePlan'
+          editor: 'Neos.Neos/Inspector/Editors/DateTimeEditor'

--- a/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/NodeTypes/ReleasePlan.fusion
+++ b/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/NodeTypes/ReleasePlan.fusion
@@ -5,14 +5,46 @@ prototype(Neos.NeosIo:ReleasePlan) < prototype(Neos.Neos:ContentComponent) {
         itemName = 'releaseVersion'
         itemRenderer = Neos.Fusion:DataStructure {
             version = ${q(releaseVersion).property('version')}
+            @context {
+                segmentsFromVersion = Neos.Fusion:DataStructure {
+                    @context {
+                        releaseDate = ${q(releaseVersion).property('releaseDate')}
+                        activeSupportUntil = ${q(releaseVersion).property('activeSupportUntil')}
+                        endOfLife = ${q(releaseVersion).property('endOfLife')}
+                    }
+                    0 = Neos.Fusion:DataStructure {
+                        start = ${Date.format(releaseDate, 'Y-m-d')}
+                        end = ${Date.format(activeSupportUntil, 'Y-m-d')}
+                        task = Neos.Fusion:Case {
+                            released {
+                                condition = ${releaseDate < Date.now()}
+                                renderer = ${'Released: ' + Date.format(releaseDate, 'F jS, Y') + String.chr(10) + 'Bugfixes until: ' + Date.format(activeSupportUntil, 'F Y')}
+                            }
+                            planned {
+                                condition = true
+                                renderer = ${'Planned Release: ' + Date.format(releaseDate, 'F Y') + String.chr(10) + 'Bugfixes until: ' + Date.format(activeSupportUntil, 'F Y')}
+                            }
+                        }
+                        @if.has = ${releaseDate && activeSupportUntil}
+                    }
+                    1 = Neos.Fusion:DataStructure {
+                        start = ${Date.format(q(releaseVersion).property('activeSupportUntil'), 'Y-m-d')}
+                        end = ${Date.format(q(releaseVersion).property('endOfLife'), 'Y-m-d')}
+                        task = ${'Security Updates until: ' + Date.format(endOfLife, 'F Y')}
+                        @if.has = ${activeSupportUntil && endOfLife}
+                    }
+                }
+            }
             segments = Neos.Fusion:Map {
                 items = ${q(releaseVersion).find('[instanceof Neos.NeosIo:ReleasePlan.Segment]')}
                 itemName = 'versionSegment'
                 itemRenderer = Neos.Fusion:DataStructure {
-                    start = ${Date.format(q(versionSegment).property('start'), 'Y-m')}
-                    end = ${Date.format(q(versionSegment).property('end'), 'Y-m')}
+                    start = ${Date.format(q(versionSegment).property('start'), 'Y-m-d')}
+                    end = ${Date.format(q(versionSegment).property('end'), 'Y-m-d')}
                     task = ${q(versionSegment).property('task')}
                 }
+
+                @process.addSegmentsFromVersion = ${Array.concat(segmentsFromVersion, value)}
             }
         }
     }

--- a/DistributionPackages/Neos.NeosIo/Resources/Private/JavaScript/Components/AmChart.js
+++ b/DistributionPackages/Neos.NeosIo/Resources/Private/JavaScript/Components/AmChart.js
@@ -19,7 +19,7 @@ const config = {
     precision: 1,
     graph: {
         fillAlphas: 1,
-        balloonText: '<b>[[task]]</b>: [[open]]-[[value]]'
+        balloonText: '[[task]]'
     },
     rotate: true,
     categoryField: 'version',
@@ -45,7 +45,7 @@ const config = {
         enabled: true,
         divId: 'exportContainer',
         position: 'bottom-right',
-        fileName: 'typo3-support-times',
+        fileName: 'neos-support-times',
         menu: ['PNG', 'PDF', 'SVG']
     }
 };


### PR DESCRIPTION
This adjusts the Neos/Flow Release plan so that it doesn't wrongly
suggests the 1st of a Month as the release date by changing the date
format from "Apr 01, 2021" to "April 2021".

It also comes with some further tweaks:

* Add release dates to the version node so that segment nodes only have
  to be added if needed (not the case so far)
* In the Backend render the version label in the structure tree to make it
  easier to find the right one
* Add version and segment properties to the creation dialog
* Turn the "task" property into a text area in order to allow multi-line
  hover texts