### PR TITLE
Add Carbon Packages Namespace to typeMapping

### DIFF
--- a/DistributionPackages/Neos.MarketPlace/Configuration/Settings.yaml
+++ b/DistributionPackages/Neos.MarketPlace/Configuration/Settings.yaml
@@ -9,6 +9,7 @@ Neos:
       neos-framework: neos-framework
       neos-build: neos-build
       neos-boilerplate: neos-boilerplate
+      neos-carbon: neos-carbon
     vendorMapping:
       neos: true
       flowpack: true


### PR DESCRIPTION
The packages from https://github.com/CarbonPackages have an own namespace to collect these little helpers into one folder. To make sure these get also listed on neos.io, I've added the typeMapping `neos-carbon`