### PR TITLE
BUGFIX: Hide Google+ accounts

### DIFF
--- a/DistributionPackages/Neos.NeosIo/Resources/Private/Templates/FusionObjects/CrowdUserProfile.html
+++ b/DistributionPackages/Neos.NeosIo/Resources/Private/Templates/FusionObjects/CrowdUserProfile.html
@@ -65,6 +65,7 @@
         <f:case value="neos_origin"></f:case>
         <f:case value="neos_bio"></f:case>
         <f:case value="neos_contribution"></f:case>
+        <f:case value="neos_googleplus"></f:case>
         <f:defaultCase>
             <li>
                 <b>


### PR DESCRIPTION
Currently, if someone has a key with `neos_googleplus`, this will show up on the teams' page. But Google+ doesn't exist anymore

![CleanShot 2021-11-26 at 19 35 30@2x](https://user-images.githubusercontent.com/4510166/143620173-8aee6cc6-1136-456e-b768-2b8b956146f9.png)