### PR TITLE
Fix pagination issue

### DIFF
--- a/DistributionPackages/Neos.MarketPlace/Classes/Eel/ElasticSearchQueryBuilder.php
+++ b/DistributionPackages/Neos.MarketPlace/Classes/Eel/ElasticSearchQueryBuilder.php
@@ -36,7 +36,6 @@ class ElasticSearchQueryBuilder extends Eel\ElasticSearchQueryBuilder
     {
         $request = parent::getRequest();
         $copiedRequest = clone $request;
-        self::skipAbandonedPackages($copiedRequest);
         if ($this->hasFulltext !== false) {
             self::enforceFunctionScoring($copiedRequest);
         }
@@ -79,19 +78,6 @@ class ElasticSearchQueryBuilder extends Eel\ElasticSearchQueryBuilder
         return $this;
     }
 
-    /**
-     * @param QueryInterface $request
-     * @return void
-     * @throws QueryBuildingException
-     */
-    protected static function skipAbandonedPackages(QueryInterface $request): void
-    {
-        $request->appendAtPath('query.bool.filter.bool.must_not', [
-            'exists' => [
-                'field' => 'abandoned'
-            ]
-        ]);
-    }
 
     /**
      * @param QueryInterface $request

--- a/DistributionPackages/Neos.MarketPlace/Configuration/Settings.yaml
+++ b/DistributionPackages/Neos.MarketPlace/Configuration/Settings.yaml
@@ -11,6 +11,7 @@ Neos:
         - '7.1'
         - '7.2'
         - '7.3'
+        - '8.0'
       neos/flow:
         - '4.3'
         - '5.3'
@@ -19,6 +20,7 @@ Neos:
         - '7.1'
         - '7.2'
         - '7.3'
+        - '8.0'
     # composer types to include, optional with a mapping to a current type
     typeMapping:
       neos-plugin: neos-plugin

--- a/DistributionPackages/Neos.MarketPlace/Resources/Private/Fusion/FusionObjects/Search.fusion
+++ b/DistributionPackages/Neos.MarketPlace/Resources/Private/Fusion/FusionObjects/Search.fusion
@@ -6,7 +6,7 @@ prototype(Neos.MarketPlace:Search) < prototype(Flowpack.SearchPlugin:Search) {
     }
 
     configuration {
-        itemsPerPage = 30
+        itemsPerPage = 3
         insertAbove = false
         insertBelow = true
         maximumNumberOfLinks = 5
@@ -40,6 +40,9 @@ prototype(Neos.MarketPlace:Search) < prototype(Flowpack.SearchPlugin:Search) {
         flowCompatibility {
             expression = ${value.exactMatch('__flowCompatibility', selectedVersion)}
             @if.flowVersion = ${selectedPackage == 'flow' && selectedVersion}
+        }
+        abandoned {
+            expression = ${value.exclude('abandoned', '1')}
         }
         sort {
             expression = ${value.sortDesc('lastActivity')}

--- a/DistributionPackages/Neos.MarketPlace/Resources/Private/Fusion/FusionObjects/Search.fusion
+++ b/DistributionPackages/Neos.MarketPlace/Resources/Private/Fusion/FusionObjects/Search.fusion
@@ -6,7 +6,7 @@ prototype(Neos.MarketPlace:Search) < prototype(Flowpack.SearchPlugin:Search) {
     }
 
     configuration {
-        itemsPerPage = 3
+        itemsPerPage = 30
         insertAbove = false
         insertBelow = true
         maximumNumberOfLinks = 5


### PR DESCRIPTION
This fix should show the pagination on package search again
The pagination would not occur due to different query handling in paginate-count and marketplace query.
The reason was the "abandoned" field that was set to be excluded. In reality it is set anyways, but in abandoned packages is being set to 1 (string).
Removed exist query and added it to fusion so as to match the index. Now pagination shows up again