### PR TITLE
BUGFIX: remove min-height of more talks link

### DIFF
--- a/DistributionPackages/Neos.NeosConIo/Resources/Private/Scss/Organisms/_Talk.scss
+++ b/DistributionPackages/Neos.NeosConIo/Resources/Private/Scss/Organisms/_Talk.scss
@@ -1,6 +1,5 @@
 .imageTeaser--relatedTalk {
   height: 100%;
-  min-height: 0;
 
   .imageTeaser__image {
     position: relative;


### PR DESCRIPTION
Hello Neos Team,

I found a small design issue on the Neoscon website. 

The "More Talks" links section was broken because of the `min-height` property if only one talk was listed on the site:

## Before my change:
![Before](https://user-images.githubusercontent.com/39345336/164972319-3ce7d858-a452-4d08-9093-31a47bc97f3e.png)

Example: https://www.neoscon.io/speakers/roland-schutz.html

## After my change:
![After](https://user-images.githubusercontent.com/39345336/164972325-0d27f30b-f117-4470-b6a1-c00a8fe4cb27.png)

However, on a page that lists several talks, I noticed that the area now pulls down when an image is deposited.:

![Bildschirmfoto 2022-04-24 um 12 55 56](https://user-images.githubusercontent.com/39345336/164973443-1e86faf1-0fb2-4ba9-b682-40ec0bf07096.png)
