### PR TITLE
FEATURE: Add meta description to show package description on google

### DIFF
--- a/DistributionPackages/Neos.MarketPlace/Resources/Private/Fusion/Documents/Package.fusion
+++ b/DistributionPackages/Neos.MarketPlace/Resources/Private/Fusion/Documents/Package.fusion
@@ -3,6 +3,7 @@ prototype(Neos.MarketPlace:Package) < prototype(Neos.MarketPlace:DefaultPage) {
     prototype(Neos.Seo:MetaDescriptionTag) {
         attributes {
             content = ${q(node).property('description')}
+            content.@process.crop = ${String.cropAtWord(value, 160, '…')}
         }
         @if.isNotBlank = ${!String.isBlank(q(node).property('description'))}
     }

--- a/DistributionPackages/Neos.MarketPlace/Resources/Private/Fusion/Documents/Package.fusion
+++ b/DistributionPackages/Neos.MarketPlace/Resources/Private/Fusion/Documents/Package.fusion
@@ -1,4 +1,12 @@
 prototype(Neos.MarketPlace:Package) < prototype(Neos.MarketPlace:DefaultPage) {
+
+    prototype(Neos.Seo:MetaDescriptionTag) {
+        attributes {
+            content = ${q(node).property('description')}
+        }
+        @if.isNotBlank = ${!String.isBlank(q(node).property('description'))}
+    }
+
     body {
         templatePath = 'resource://Neos.MarketPlace/Private/Templates/Documents/Package.html'
 

--- a/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/FusionObjects/MetaTags.fusion
+++ b/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/FusionObjects/MetaTags.fusion
@@ -7,8 +7,11 @@ prototype(Neos.NeosIo:MetaTags) < prototype(Neos.Fusion:Component) {
         @process.append = ${(String.endsWith(value, '/') ? value : value + '/') + 'rss.xml'}
     }
 
+    description = ${q(node).property('description')}
+
     renderer = afx`
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="description" content={props.description} @if.hasMetaDescription={props.description} />
         <meta name="apple-itunes-app" content={'app-id=' + props.iOSAppId} @if.enabled={props.showSmartAppBanner}/>
         <link rel="alternate" type="application/rss+xml" title="RSS-Feed" href={props.rssUri}/>
 

--- a/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/FusionObjects/MetaTags.fusion
+++ b/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/FusionObjects/MetaTags.fusion
@@ -7,11 +7,8 @@ prototype(Neos.NeosIo:MetaTags) < prototype(Neos.Fusion:Component) {
         @process.append = ${(String.endsWith(value, '/') ? value : value + '/') + 'rss.xml'}
     }
 
-    description = ${q(node).property('description')}
-
     renderer = afx`
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="description" content={props.description} @if.hasMetaDescription={props.description} />
         <meta name="apple-itunes-app" content={'app-id=' + props.iOSAppId} @if.enabled={props.showSmartAppBanner}/>
         <link rel="alternate" type="application/rss+xml" title="RSS-Feed" href={props.rssUri}/>
 


### PR DESCRIPTION
## Description

When searching for a Neos package on any search engine, the description doesn't really give helpful information about the actual package. This pull request adds a `<meta>` tag for the description. With this, the meta description looks cleaner on search engines

![Screenshot at May 26 23-25-45](https://user-images.githubusercontent.com/39345336/170582756-bafaf8d1-5aed-43c1-a6ed-7ed8a69bbf51.png)

