### PR TITLE
BUGFIX: Prevent lower version from appearing as package search result

### DIFF
--- a/DistributionPackages/Neos.MarketPlace/Classes/Service/PackageVersion.php
+++ b/DistributionPackages/Neos.MarketPlace/Classes/Service/PackageVersion.php
@@ -48,17 +48,10 @@ class PackageVersion
     public function extractLastVersion(NodeInterface $node): ?NodeInterface
     {
         $versions = $this->extractVersions($node);
-        usort($versions, static function(NodeInterface $a, NodeInterface $b) {
-            /** @var \DateTime $aTime */
-            $aTime = $a->getProperty('time');
-            /** @var \DateTime $bTime */
-            $bTime = $b->getProperty('time');
-            if ($aTime === false || $bTime === false) {
-                return -1;
-        }
-            return $bTime->getTimestamp() - $aTime->getTimestamp();
+        usort($versions, static function (NodeInterface $a, NodeInterface $b) {
+            return $a->getProperty('versionNormalized') <=> $b->getProperty('versionNormalized');
         });
-        $stableVersions = array_filter($versions, static function(NodeInterface $version) {
+        $stableVersions = array_filter($versions, static function (NodeInterface $version) {
             return $version->getProperty('stability') === true;
         });
         if (count($stableVersions) > 0) {


### PR DESCRIPTION
By defining the highest package version as „lastVersion“ we prevent f.e.
that a later release version 5.0.2 is shown as result instead of a 8.0.2 which was released 2 minutes earlier.

Resolves: #409