### PR TITLE
TASK: Future release (phases) shown in gray

### DIFF
--- a/DistributionPackages/Neos.NeosIo.ReleasePlan/Resources/Private/JavaScript/Components/AmChart.js
+++ b/DistributionPackages/Neos.NeosIo.ReleasePlan/Resources/Private/JavaScript/Components/AmChart.js
@@ -6,6 +6,7 @@ import amChartGantt from "amcharts3/amcharts/gantt";
 import BaseComponent from "DistributionPackages/Neos.NeosIo/Resources/Private/JavaScript/Components/BaseComponent";
 
 const themeColor = '#26224C';
+const themeColorFuture = '#888888';
 
 const config = {
     type: 'gantt',
@@ -103,7 +104,12 @@ class AmChart extends BaseComponent {
         return data.map(obj => {
             return Object.assign({}, obj, {
                 segments: obj.segments.map((segment, index) => {
-                    const color = lighten(themeColor, index * 10);
+                    let color;
+                    if (Date.parse(segment.start) > Date.now()) {
+                        color = lighten(themeColorFuture, (index * 10));
+                    } else {
+                        color = lighten(themeColor, index * 10);
+                    }
 
                     return Object.assign({}, segment, {
                         color


### PR DESCRIPTION
As discussed in Hamburg during the sprint, this might make the status of "planned" releases a bit clearer.

It looks like this:

<img width="935" alt="image" src="https://user-images.githubusercontent.com/95873/195406479-f43a6f40-c7e7-4eda-8428-b9db4f891d7a.png">
