### PR TITLE
TASK: Remove facebook and twitter from the footer

### DIFF
--- a/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/Components/SiteFooter.fusion
+++ b/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/Components/SiteFooter.fusion
@@ -34,8 +34,6 @@ prototype(Neos.NeosIo:Component.SiteFooter.Renderer) < prototype(Neos.Fusion:Com
                     <ul class="nav nav--stacked siteFooter__nav">
                         <li><a target="_blank" rel="noopener" href="https://github.com/neos"><i class="fab fa-fw fa-github"></i> GitHub</a></li>
                         <li><a rel="me noopener" target="_blank" href="https://neos.social/@team"><i class="fab fa-fw fa-mastodon"></i> Mastodon</a></li>
-                        <li><a target="_blank" rel="noopener" href="https://twitter.com/NeosCMS"><i class="fab fa-fw fa-twitter"></i> Twitter</a></li>
-                        <li><a target="_blank" rel="noopener" href="https://www.facebook.com/NeosCMS"><i class="fab fa-fw fa-facebook"></i> Facebook</a></li>
                         <li><a target="_blank" rel="noopener" href="https://youtube.com/c/NeosCMS"><i class="fab fa-fw fa-youtube"></i> YouTube</a></li>
                     </ul>
                 </div>


### PR DESCRIPTION
We as a team don't use Facebook and Twitter currently, so we can remove the accounts from the website footer.