### PR TITLE
Adjust Local Beach configuration

### DIFF
--- a/.localbeach.dist.env
+++ b/.localbeach.dist.env
@@ -3,7 +3,7 @@
 #
 
 BEACH_PROJECT_NAME=neosio
-BEACH_VIRTUAL_HOSTS=neosio.localbeach.net,flowio.localbeach.net,neoscon.localbeach.net
+BEACH_VIRTUAL_HOSTS=neosio.localbeach.net,flowneosio.localbeach.net,neoscon.localbeach.net
 
 # Change the PHP version to the branch you use in your Beach instances.
 # Examples: 7.4 for PHP 7.4.x

--- a/.localbeach.docker-compose.yaml
+++ b/.localbeach.docker-compose.yaml
@@ -57,13 +57,14 @@ services:
       - BEACH_PHP_TIMEZONE=${BEACH_PHP_TIMEZONE:-UTC}
       - BEACH_APPLICATION_USER_SERVICE_ENABLE=${BEACH_APPLICATION_USER_SERVICE_ENABLE:-false}
       - BEACH_APPLICATION_STARTUP_SCRIPTS_ENABLE=${BEACH_APPLICATION_STARTUP_SCRIPTS_ENABLE:-false}
+      - BEACH_APPLICATION_CUSTOM_STARTUP_SCRIPTS_ENABLE=${BEACH_APPLICATION_CUSTOM_STARTUP_SCRIPTS_ENABLE:-false}
       - ELASTICSEARCH_HOSTNAME=${ELASTICSEARCH_HOSTNAME:-neosio_elasticsearch.local_beach}
       - ELASTICSEARCH_PORT=${ELASTICSEARCH_PORT:-9200}
       - ELASTICSEARCH_USERNAME=${ELASTICSEARCH_USERNAME}
       - ELASTICSEARCH_PASSWORD=${ELASTICSEARCH_PASSWORD}
-      - CROWD_API_USERNAME=${CROWD_API_USERNAME}
-      - CROWD_API_PASSWORD=${CROWD_API_PASSWORD}
-      - GITHUB_API_TOKEN=${GITHUB_API_TOKEN}
+      - CROWD_API_USERNAME=${CROWD_API_USERNAME:-}
+      - CROWD_API_PASSWORD=${CROWD_API_PASSWORD:-}
+      - GITHUB_API_TOKEN=${GITHUB_API_TOKEN:-}
 
   redis:
     image: ${BEACH_REDIS_IMAGE:-flownative/redis}:${BEACH_REDIS_IMAGE_VERSION:-latest}
@@ -78,21 +79,3 @@ services:
       interval: 1s
       timeout: 5s
       retries: 120
-
-  elasticsearch:
-    image: ${BEACH_ELASTICSEARCH_IMAGE:-flownative/elasticsearch}:${BEACH_ELASTICSEARCH_IMAGE_VERSION:-5.6}
-    container_name: ${BEACH_PROJECT_NAME:?Please specify a Beach project name as BEACH_PROJECT_NAME}_elasticsearch
-    networks:
-      - local_beach
-    ports:
-      - 9200:9200
-    volumes:
-      - ./.LocalBeach/elasticsearch/data:/usr/share/elasticsearch/data
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-    environment:
-      - cluster.name=neosio
-      - discovery.type=single-node
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"

--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@ The official neos.io website package.
 
 Clone the repository, and setup Neos as always:
 
-- Set up local beach as described here: https://www.flownative.com/en/documentation/guides/localbeach/local-beach-setup-docker-based-neos-development-howto.html
+- Set up Local Beach as described here: https://www.flownative.com/en/documentation/guides/localbeach/local-beach-setup-docker-based-neos-development-howto.html
 - Run `composer install`
 - Run `beach start`
 - Run `beach exec` to enter the container
 - Inside the container run `./flow doctrine:migrate` and site imports etc. as needed
+- add the following domains:
+  - `./flow domain:add --site-node-name neosio --hostname neosio.localbeach.net --scheme https`
+  - `./flow domain:add --site-node-name flowneosio --hostname flowneosio.localbeach.net --scheme https`
+  - `./flow domain:add --site-node-name neosconio --hostname neosconio.localbeach.net --scheme https`
 
 _Note: We require [nvm](https://github.com/creationix/nvm#install-script) as well as the `yarn` binary to be installed on your system._
 


### PR DESCRIPTION
This fixes an issue with start up scripts and adds instructions to README.md for how to add domains in order to access the different sites via localbeach.net domains.

The Elasticsearch container was removed for now, as the given version is incompatible with the current implementation.