### PR TITLE
FIX: logo bar cut off

### DIFF
--- a/DistributionPackages/Neos.Presentation/Resources/Private/Fusion/Molecule/LogoBar/LogoBar.fusion
+++ b/DistributionPackages/Neos.Presentation/Resources/Private/Fusion/Molecule/LogoBar/LogoBar.fusion
@@ -39,7 +39,7 @@ prototype(Neos.Presentation:LogoBar) < prototype(Neos.Fusion:Component) {
         >
             <ul
                 x-random-children
-                class={['flex item-list items-center [&_li]:mx-16', private.duplications ? 'animate-infinite-scroll' : null]}
+                class={['flex item-list items-center [&_li]:mx-28', private.duplications ? 'animate-infinite-scroll' : null]}
             >
                 <Neos.Fusion:Loop items={props.assets}>
                     <li @if={item.src}><img class="max-h-10 md:max-h-16 max-w-none" alt={item.alternativeText} src={item.src}/></li>

--- a/DistributionPackages/Neos.Presentation/Resources/Private/Fusion/Molecule/LogoBar/LogoBar.fusion
+++ b/DistributionPackages/Neos.Presentation/Resources/Private/Fusion/Molecule/LogoBar/LogoBar.fusion
@@ -25,7 +25,6 @@ prototype(Neos.Presentation:LogoBar) < prototype(Neos.Fusion:Component) {
 
     assets = null
     grayscale = false
-    gap = 'gap-28'
 
     @private {
         numberOfAssets = ${Type.isArray(props.assets) ? Array.length(props.assets) : 0}
@@ -35,12 +34,12 @@ prototype(Neos.Presentation:LogoBar) < prototype(Neos.Fusion:Component) {
     renderer = afx`
         <div
             @if={private.numberOfAssets}
-            class={['flex justify-center overflow-x-clip', props.grayscale ? 'grayscale' : null, props.gap]}
+            class={['flex justify-center overflow-x-clip', props.grayscale ? 'grayscale' : null]}
             x-data={AlpineJS.xData('LogoBar', private.duplications)}
         >
             <ul
                 x-random-children
-                class={['flex item-list items-center', props.gap, private.duplications ? 'animate-infinite-scroll' : null]}
+                class={['flex item-list items-center [&_li]:mx-16', private.duplications ? 'animate-infinite-scroll' : null]}
             >
                 <Neos.Fusion:Loop items={props.assets}>
                     <li @if={item.src}><img class="max-h-10 md:max-h-16 max-w-none" alt={item.alternativeText} src={item.src}/></li>

--- a/DistributionPackages/Neos.Presentation/Resources/Private/Fusion/Molecule/LogoBar/LogoBar.fusion
+++ b/DistributionPackages/Neos.Presentation/Resources/Private/Fusion/Molecule/LogoBar/LogoBar.fusion
@@ -39,7 +39,7 @@ prototype(Neos.Presentation:LogoBar) < prototype(Neos.Fusion:Component) {
         >
             <ul
                 x-random-children
-                class={['flex item-list items-center [&_li]:mx-28', private.duplications ? 'animate-infinite-scroll' : null]}
+                class={['flex item-list items-center *:mx-14', private.duplications ? 'animate-infinite-scroll' : null]}
             >
                 <Neos.Fusion:Loop items={props.assets}>
                     <li @if={item.src}><img class="max-h-10 md:max-h-16 max-w-none" alt={item.alternativeText} src={item.src}/></li>


### PR DESCRIPTION
- fixed LogoBar cut-off jump at the end of each animation cycle due to gap property
- has now been tested on Linux (Chrome) and MacOS (Safari 17.3)