### PR TITLE
FIX: Allow VideoEmbed NodeType inside Columns

### DIFF
--- a/DistributionPackages/Neos.NeosIo/NodeTypes/Content/VideoEmbed.yaml
+++ b/DistributionPackages/Neos.NeosIo/NodeTypes/Content/VideoEmbed.yaml
@@ -1,6 +1,8 @@
 'Neos.NeosIo:VideoEmbed':
   superTypes:
     'Neos.Neos:Content': true
+    'Neos.Neos:ContentCollection': true
+    Neos.NeosIo:Constraints.Column: true
   ui:
     label: 'Video (autoplay, looped and muted)'
     icon: 'fas fa-play-circle'


### PR DESCRIPTION
to allow little Neos UI videos to highlight features - be placed inside e.g. twoColumn elements (again)

There is currently content where the VideoEmbed is inside a TwoColumn Element, see: https://www.neos.io/features/inline-editing-true-wysiwyg.html

[This change](https://github.com/neos/Neos.NeosIo/commit/b58827bf74213d9294cf910a59974c65683bcc35) reworked the node constraints and now the VideoEmbed element cannot be added inside columns any more.