### PR TITLE
TASK: Upgrade to latest Neos versions

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1866,16 +1866,16 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "2.20.3",
+            "version": "2.20.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "17d28b5c4cac212ca92730d9a26e32a0b1516126"
+                "reference": "71550106d491c3f888636b731c805473de3c8583"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/17d28b5c4cac212ca92730d9a26e32a0b1516126",
-                "reference": "17d28b5c4cac212ca92730d9a26e32a0b1516126",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/71550106d491c3f888636b731c805473de3c8583",
+                "reference": "71550106d491c3f888636b731c805473de3c8583",
                 "shasum": ""
             },
             "require": {
@@ -1962,9 +1962,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/orm/issues",
-                "source": "https://github.com/doctrine/orm/tree/2.20.3"
+                "source": "https://github.com/doctrine/orm/tree/2.20.4"
             },
-            "time": "2025-05-02T17:07:53+00:00"
+            "time": "2025-06-09T20:24:12+00:00"
         },
         {
             "name": "doctrine/persistence",
@@ -3392,16 +3392,16 @@
         },
         {
             "name": "google/cloud-core",
-            "version": "v1.62.3",
+            "version": "v1.63.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-cloud-php-core.git",
-                "reference": "0c19d76e7f3b6810c4f2cc1330c693af2681c601"
+                "reference": "14461f7b53b261caeed7174f9d704d10881b02c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-cloud-php-core/zipball/0c19d76e7f3b6810c4f2cc1330c693af2681c601",
-                "reference": "0c19d76e7f3b6810c4f2cc1330c693af2681c601",
+                "url": "https://api.github.com/repos/googleapis/google-cloud-php-core/zipball/14461f7b53b261caeed7174f9d704d10881b02c2",
+                "reference": "14461f7b53b261caeed7174f9d704d10881b02c2",
                 "shasum": ""
             },
             "require": {
@@ -3452,9 +3452,9 @@
             ],
             "description": "Google Cloud PHP shared dependency, providing functionality useful to all components.",
             "support": {
-                "source": "https://github.com/googleapis/google-cloud-php-core/tree/v1.62.3"
+                "source": "https://github.com/googleapis/google-cloud-php-core/tree/v1.63.0"
             },
-            "time": "2025-05-20T19:49:54+00:00"
+            "time": "2025-06-13T20:36:13+00:00"
         },
         {
             "name": "google/cloud-storage",
@@ -5299,7 +5299,7 @@
         },
         {
             "name": "neos/contentgraph-doctrinedbaladapter",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/contentgraph-doctrinedbaladapter.git",
@@ -5345,7 +5345,7 @@
         },
         {
             "name": "neos/contentrepository-core",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/contentrepository-core.git",
@@ -5405,7 +5405,7 @@
         },
         {
             "name": "neos/contentrepository-export",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/contentrepository-export.git",
@@ -5458,16 +5458,16 @@
         },
         {
             "name": "neos/contentrepository-legacynodemigration",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/contentrepository-legacynodemigration.git",
-                "reference": "458a40560304b3981e5c46911db9430e2326af3c"
+                "reference": "07be5dd38accb7a13c4cbf09fea86ef4c991c214"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/neos/contentrepository-legacynodemigration/zipball/458a40560304b3981e5c46911db9430e2326af3c",
-                "reference": "458a40560304b3981e5c46911db9430e2326af3c",
+                "url": "https://api.github.com/repos/neos/contentrepository-legacynodemigration/zipball/07be5dd38accb7a13c4cbf09fea86ef4c991c214",
+                "reference": "07be5dd38accb7a13c4cbf09fea86ef4c991c214",
                 "shasum": ""
             },
             "require": {
@@ -5503,20 +5503,20 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-04-04T16:45:07+00:00"
+            "time": "2025-06-01T10:39:26+00:00"
         },
         {
             "name": "neos/contentrepository-nodeaccess",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/contentrepository-nodeaccess.git",
-                "reference": "35f6733c07d72e88880591bda1c0c872a47a1df0"
+                "reference": "735268ef8826856d4c9ac3fd1697628a65ace38a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/neos/contentrepository-nodeaccess/zipball/35f6733c07d72e88880591bda1c0c872a47a1df0",
-                "reference": "35f6733c07d72e88880591bda1c0c872a47a1df0",
+                "url": "https://api.github.com/repos/neos/contentrepository-nodeaccess/zipball/735268ef8826856d4c9ac3fd1697628a65ace38a",
+                "reference": "735268ef8826856d4c9ac3fd1697628a65ace38a",
                 "shasum": ""
             },
             "require": {
@@ -5627,11 +5627,11 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-04-02T10:05:05+00:00"
+            "time": "2025-06-02T20:43:15+00:00"
         },
         {
             "name": "neos/contentrepository-nodemigration",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/contentrepository-nodemigration.git",
@@ -5767,7 +5767,7 @@
         },
         {
             "name": "neos/contentrepository-structureadjustment",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/contentrepository-structureadjustment.git",
@@ -5903,16 +5903,16 @@
         },
         {
             "name": "neos/contentrepositoryregistry",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/contentrepositoryregistry.git",
-                "reference": "a81a88d8928e1a9722ed10d469b0f06b2678d3bc"
+                "reference": "92e386d879c9089e2aa5798e00819610d72cd111"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/neos/contentrepositoryregistry/zipball/a81a88d8928e1a9722ed10d469b0f06b2678d3bc",
-                "reference": "a81a88d8928e1a9722ed10d469b0f06b2678d3bc",
+                "url": "https://api.github.com/repos/neos/contentrepositoryregistry/zipball/92e386d879c9089e2aa5798e00819610d72cd111",
+                "reference": "92e386d879c9089e2aa5798e00819610d72cd111",
                 "shasum": ""
             },
             "require": {
@@ -5946,11 +5946,11 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-04-03T13:22:30+00:00"
+            "time": "2025-06-13T19:27:24+00:00"
         },
         {
             "name": "neos/diff",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/diff.git",
@@ -6740,7 +6740,7 @@
         },
         {
             "name": "neos/fusion",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/fusion.git",
@@ -6878,7 +6878,7 @@
         },
         {
             "name": "neos/fusion-afx",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/fusion-afx.git",
@@ -7177,7 +7177,7 @@
         },
         {
             "name": "neos/media",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/media.git",
@@ -7323,16 +7323,16 @@
         },
         {
             "name": "neos/media-browser",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/media-browser.git",
-                "reference": "44cbda8a831844c8735734a8eab1b559762e98e0"
+                "reference": "82daa7a8f08a91276c655c9b90ea800d9bc1c2ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/neos/media-browser/zipball/44cbda8a831844c8735734a8eab1b559762e98e0",
-                "reference": "44cbda8a831844c8735734a8eab1b559762e98e0",
+                "url": "https://api.github.com/repos/neos/media-browser/zipball/82daa7a8f08a91276c655c9b90ea800d9bc1c2ca",
+                "reference": "82daa7a8f08a91276c655c9b90ea800d9bc1c2ca",
                 "shasum": ""
             },
             "require": {
@@ -7454,20 +7454,20 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-05-14T19:33:52+00:00"
+            "time": "2025-06-13T19:27:24+00:00"
         },
         {
             "name": "neos/neos",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/neos.git",
-                "reference": "2cdd6bb517b919bbdf36d5125f0c52a55dae8d92"
+                "reference": "e7d41f653ac27160595c508cf89332f029925da8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/neos/neos/zipball/2cdd6bb517b919bbdf36d5125f0c52a55dae8d92",
-                "reference": "2cdd6bb517b919bbdf36d5125f0c52a55dae8d92",
+                "url": "https://api.github.com/repos/neos/neos/zipball/e7d41f653ac27160595c508cf89332f029925da8",
+                "reference": "e7d41f653ac27160595c508cf89332f029925da8",
                 "shasum": ""
             },
             "require": {
@@ -7480,7 +7480,7 @@
                 "neos/fluid-adaptor": "~9.0.0",
                 "neos/fusion": "self.version",
                 "neos/fusion-afx": "self.version",
-                "neos/fusion-form": "^2.0 || ^3.0",
+                "neos/fusion-form": "^2.1 || ^3.0",
                 "neos/media": "self.version",
                 "neos/media-browser": "self.version",
                 "neos/party": "~7.0.3",
@@ -7616,20 +7616,20 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-05-14T20:43:42+00:00"
+            "time": "2025-06-13T19:59:50+00:00"
         },
         {
             "name": "neos/neos-ui",
-            "version": "9.0.0",
+            "version": "9.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/neos-ui.git",
-                "reference": "85303b217019c922560e4a7b7c6b858d6a20e5f2"
+                "reference": "a86d2b6f7f16ac5e6c138a2ff521d10396e61e75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/neos/neos-ui/zipball/85303b217019c922560e4a7b7c6b858d6a20e5f2",
-                "reference": "85303b217019c922560e4a7b7c6b858d6a20e5f2",
+                "url": "https://api.github.com/repos/neos/neos-ui/zipball/a86d2b6f7f16ac5e6c138a2ff521d10396e61e75",
+                "reference": "a86d2b6f7f16ac5e6c138a2ff521d10396e61e75",
                 "shasum": ""
             },
             "require": {
@@ -7727,7 +7727,7 @@
             "description": "Neos CMS UI written in React",
             "support": {
                 "issues": "https://github.com/neos/neos-ui/issues",
-                "source": "https://github.com/neos/neos-ui/tree/9.0.0"
+                "source": "https://github.com/neos/neos-ui/tree/9.0.1"
             },
             "funding": [
                 {
@@ -7735,20 +7735,20 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-04-03T12:26:32+00:00"
+            "time": "2025-06-15T08:58:46+00:00"
         },
         {
             "name": "neos/neos-ui-compiled",
-            "version": "9.0.0",
+            "version": "9.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/neos-ui-compiled.git",
-                "reference": "1da7aeaf5de084e8c1cbe530e11cb0d52acf0e05"
+                "reference": "f2d6183fcf5064ef22a7f97c00db5e586578e7c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/neos/neos-ui-compiled/zipball/1da7aeaf5de084e8c1cbe530e11cb0d52acf0e05",
-                "reference": "1da7aeaf5de084e8c1cbe530e11cb0d52acf0e05",
+                "url": "https://api.github.com/repos/neos/neos-ui-compiled/zipball/f2d6183fcf5064ef22a7f97c00db5e586578e7c3",
+                "reference": "f2d6183fcf5064ef22a7f97c00db5e586578e7c3",
                 "shasum": ""
             },
             "require": {
@@ -7768,7 +7768,7 @@
             "notification-url": "https://packagist.org/downloads/",
             "support": {
                 "issues": "https://github.com/neos/neos-ui-compiled/issues",
-                "source": "https://github.com/neos/neos-ui-compiled/tree/9.0.0"
+                "source": "https://github.com/neos/neos-ui-compiled/tree/9.0.1"
             },
             "funding": [
                 {
@@ -7776,7 +7776,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-04-03T13:32:40+00:00"
+            "time": "2025-06-15T09:29:27+00:00"
         },
         {
             "name": "neos/neosconio",
@@ -8661,7 +8661,7 @@
         },
         {
             "name": "neos/nodetypes",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/neos-nodetypes.git",
@@ -8808,7 +8808,7 @@
         },
         {
             "name": "neos/nodetypes-assetlist",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/nodetypes-assetlist.git",
@@ -8935,7 +8935,7 @@
         },
         {
             "name": "neos/nodetypes-basemixins",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/nodetypes-basemixins.git",
@@ -9061,7 +9061,7 @@
         },
         {
             "name": "neos/nodetypes-columnlayouts",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/nodetypes-columnlayouts.git",
@@ -9188,7 +9188,7 @@
         },
         {
             "name": "neos/nodetypes-contentreferences",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/nodetypes-contentreferences.git",
@@ -9314,7 +9314,7 @@
         },
         {
             "name": "neos/nodetypes-form",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/nodetypes-form.git",
@@ -9443,7 +9443,7 @@
         },
         {
             "name": "neos/nodetypes-html",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/nodetypes-html.git",
@@ -9570,7 +9570,7 @@
         },
         {
             "name": "neos/nodetypes-navigation",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/nodetypes-navigation.git",
@@ -10816,16 +10816,16 @@
         },
         {
             "name": "neos/workspace-ui",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/workspace-ui.git",
-                "reference": "d3d0bb3adc74ce25c0274e412f63a2f5ec5838a8"
+                "reference": "eba4ac8905f2552b3e1e2e13ca2ce935c5637255"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/neos/workspace-ui/zipball/d3d0bb3adc74ce25c0274e412f63a2f5ec5838a8",
-                "reference": "d3d0bb3adc74ce25c0274e412f63a2f5ec5838a8",
+                "url": "https://api.github.com/repos/neos/workspace-ui/zipball/eba4ac8905f2552b3e1e2e13ca2ce935c5637255",
+                "reference": "eba4ac8905f2552b3e1e2e13ca2ce935c5637255",
                 "shasum": ""
             },
             "require": {
@@ -10891,7 +10891,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-04-03T12:04:24+00:00"
+            "time": "2025-06-10T17:52:38+00:00"
         },
         {
             "name": "networkteam/neos-mailobfuscator",
@@ -15310,12 +15310,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "1eb2c3ac8130315972955def682482a1972b8d8d"
+                "reference": "0a95bcf39c5b55601cb073bc307d567a16e31dc0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/1eb2c3ac8130315972955def682482a1972b8d8d",
-                "reference": "1eb2c3ac8130315972955def682482a1972b8d8d",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/0a95bcf39c5b55601cb073bc307d567a16e31dc0",
+                "reference": "0a95bcf39c5b55601cb073bc307d567a16e31dc0",
                 "shasum": ""
             },
             "conflict": {
@@ -15478,9 +15478,12 @@
                 "dolibarr/dolibarr": "<19.0.2|==21.0.0.0-beta",
                 "dompdf/dompdf": "<2.0.4",
                 "doublethreedigital/guest-entries": "<3.1.2",
+                "drupal/admin_audit_trail": "<1.0.5",
                 "drupal/ai": "<1.0.5",
                 "drupal/alogin": "<2.0.6",
                 "drupal/cache_utility": "<1.2.1",
+                "drupal/commerce_alphabank_redirect": "<1.0.3",
+                "drupal/commerce_eurobank_redirect": "<2.1.1",
                 "drupal/config_split": "<1.10|>=2,<2.0.2",
                 "drupal/core": ">=6,<6.38|>=7,<7.102|>=8,<10.3.14|>=10.4,<10.4.5|>=11,<11.0.13|>=11.1,<11.1.5",
                 "drupal/core-recommended": ">=7,<7.102|>=8,<10.2.11|>=10.3,<10.3.9|>=11,<11.0.8",
@@ -15489,11 +15492,13 @@
                 "drupal/gdpr": "<3.0.1|>=3.1,<3.1.2",
                 "drupal/google_tag": "<1.8|>=2,<2.0.8",
                 "drupal/ignition": "<1.0.4",
+                "drupal/lightgallery": "<1.6",
                 "drupal/link_field_display_mode_formatter": "<1.6",
                 "drupal/matomo": "<1.24",
                 "drupal/oauth2_client": "<4.1.3",
                 "drupal/oauth2_server": "<2.1",
                 "drupal/obfuscate": "<2.0.1",
+                "drupal/quick_node_block": "<2",
                 "drupal/rapidoc_elements_field_formatter": "<1.0.1",
                 "drupal/spamspan": "<3.2.1",
                 "drupal/tfa": "<1.10",
@@ -15521,8 +15526,8 @@
                 "ezsystems/ezdemo-ls-extension": ">=5.4,<5.4.2.1-dev",
                 "ezsystems/ezfind-ls": ">=5.3,<5.3.6.1-dev|>=5.4,<5.4.11.1-dev|>=2017.12,<2017.12.0.1-dev",
                 "ezsystems/ezplatform": "<=1.13.6|>=2,<=2.5.24",
-                "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6|>=1.5,<1.5.29|>=2.3,<2.3.26|>=3.3,<3.3.39",
-                "ezsystems/ezplatform-admin-ui-assets": ">=4,<4.2.1|>=5,<5.0.1|>=5.1,<5.1.1",
+                "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6|>=1.5,<1.5.29|>=2.3,<2.3.38|>=3.3,<3.3.39",
+                "ezsystems/ezplatform-admin-ui-assets": ">=4,<4.2.1|>=5,<5.0.1|>=5.1,<5.1.1|>=5.3.0.0-beta1,<5.3.5",
                 "ezsystems/ezplatform-graphql": ">=1.0.0.0-RC1-dev,<1.0.13|>=2.0.0.0-beta1,<2.3.12",
                 "ezsystems/ezplatform-http-cache": "<2.3.16",
                 "ezsystems/ezplatform-kernel": "<1.2.5.1-dev|>=1.3,<1.3.35",
@@ -15604,6 +15609,7 @@
                 "guzzlehttp/oauth-subscriber": "<0.8.1",
                 "guzzlehttp/psr7": "<1.9.1|>=2,<2.4.5",
                 "haffner/jh_captcha": "<=2.1.3|>=3,<=3.0.2",
+                "handcraftedinthealps/goodby-csv": "<1.4.3",
                 "harvesthq/chosen": "<1.8.7",
                 "helloxz/imgurl": "<=2.31",
                 "hhxsv5/laravel-s": "<3.7.36",
@@ -15613,9 +15619,10 @@
                 "hov/jobfair": "<1.0.13|>=2,<2.0.2",
                 "httpsoft/http-message": "<1.0.12",
                 "hyn/multi-tenant": ">=5.6,<5.7.2",
-                "ibexa/admin-ui": ">=4.2,<4.2.3|>=4.6,<4.6.14",
+                "ibexa/admin-ui": ">=4.2,<4.2.3|>=4.6,<4.6.21",
+                "ibexa/admin-ui-assets": ">=4.6.0.0-alpha1,<4.6.21",
                 "ibexa/core": ">=4,<4.0.7|>=4.1,<4.1.4|>=4.2,<4.2.3|>=4.5,<4.5.6|>=4.6,<4.6.2",
-                "ibexa/fieldtype-richtext": ">=4.6,<4.6.19",
+                "ibexa/fieldtype-richtext": ">=4.6,<4.6.21",
                 "ibexa/graphql": ">=2.5,<2.5.31|>=3.3,<3.3.28|>=4.2,<4.2.3",
                 "ibexa/http-cache": ">=4.6,<4.6.14",
                 "ibexa/post-install": "<1.0.16|>=4.6,<4.6.14",
@@ -15986,7 +15993,7 @@
                 "spoonity/tcpdf": "<6.2.22",
                 "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
                 "ssddanbrown/bookstack": "<24.05.1",
-                "starcitizentools/citizen-skin": ">=2.6.3,<2.31",
+                "starcitizentools/citizen-skin": ">=2.4.2,<3.3.1",
                 "starcitizentools/tabber-neue": ">=1.9.1,<2.7.2",
                 "statamic/cms": "<=5.16",
                 "stormpath/sdk": "<9.9.99",
@@ -16249,7 +16256,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-09T18:07:09+00:00"
+            "time": "2025-06-13T22:05:09+00:00"
         }
     ],
     "aliases": [


### PR DESCRIPTION
  - Upgrading neos/contentrepository-core from version 9.0.3 to 9.0.4
  - Upgrading neos/contentrepository-export from version 9.0.3 to 9.0.4
  - Upgrading neos/contentrepository-legacynodemigration from version 9.0.3 to 9.0.4
  - Upgrading neos/contentrepository-nodeaccess from version 9.0.3 to 9.0.4
  - Upgrading neos/contentrepository-nodemigration from version 9.0.3 to 9.0.4
  - Upgrading neos/contentrepository-structureadjustment from version 9.0.3 to 9.0.4
  - Upgrading neos/contentrepositoryregistry from version 9.0.3 to 9.0.4
  - Upgrading neos/diff from version 9.0.3 to 9.0.4
  - Upgrading neos/fusion from version 9.0.3 to 9.0.4
  - Upgrading neos/fusion-afx from version 9.0.3 to 9.0.4
  - Upgrading neos/media from version 9.0.3 to 9.0.4
  - Upgrading neos/media-browser from version 9.0.3 to 9.0.4
  - Upgrading neos/neos from version 9.0.3 to 9.0.4
  - Upgrading neos/neos-ui from version 9.0.0 to 9.0.1
  - Upgrading neos/neos-ui-compiled from version 9.0.0 to 9.0.1
  - Upgrading neos/nodetypes from version 9.0.3 to 9.0.4
  - Upgrading neos/nodetypes-assetlist from version 9.0.3 to 9.0.4
  - Upgrading neos/nodetypes-basemixins from version 9.0.3 to 9.0.4
  - Upgrading neos/nodetypes-columnlayouts from version 9.0.3 to 9.0.4
  - Upgrading neos/nodetypes-contentreferences from version 9.0.3 to 9.0.4
  - Upgrading neos/nodetypes-form from version 9.0.3 to 9.0.4
  - Upgrading neos/nodetypes-html from version 9.0.3 to 9.0.4
  - Upgrading neos/nodetypes-navigation from version 9.0.3 to 9.0.4
  - Upgrading neos/workspace-ui from version 9.0.3 to 9.0.4
  - Upgrading neos/contentgraph-doctrinedbaladapter from version 9.0.3 to 9.0.4
  - Upgrading doctrine/orm from version 2.20.3 to 2.20.4
  - Upgrading google/cloud-core from version v1.62.3 to v1.63.0