### PR TITLE
BUGFIX: labels of stages not readable on mobile

### DIFF
--- a/DistributionPackages/Neos.NeosConIo/Resources/Private/Scss/Organisms/_Schedule.scss
+++ b/DistributionPackages/Neos.NeosConIo/Resources/Private/Scss/Organisms/_Schedule.scss
@@ -136,10 +136,8 @@ $containerWidth: 680px;
     }
     .talk__roomSmallDevice {
       display: block;
-
-      color: #ccc;
       font-size: 16px;
-      font-weight: 100 !important;
+      font-weight: 450 !important;
     }
   }
 }


### PR DESCRIPTION
**Description**

The labels of the specific stages are not very good readable on mobile. So i removed the color, and adjusted the `font-weight` a bit.

### Before
![before](https://github.com/user-attachments/assets/bb2c100a-e53f-4bd2-b743-67845a8903f7)

### After

<img width="248" alt="after" src="https://github.com/user-attachments/assets/b88395c1-2d8e-4667-8197-d6a8b6408511" />
