### PR TITLE
BUGFIX: Optimise goessential video script inclusion

### DIFF
--- a/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/Overrides/GoE.Video.fusion
+++ b/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/Overrides/GoE.Video.fusion
@@ -1,0 +1,6 @@
+prototype(GoE.Neos:Component.Element.Video) {
+    @process.appendScript = afx`
+        {value}
+        <script data-slipstream defer src="https://app.goessential.com/app/client.bundle.js"></script>
+    `
+}

--- a/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/Overrides/Page.fusion
+++ b/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/Overrides/Page.fusion
@@ -1,4 +1,9 @@
 prototype(Neos.Neos:Page) {
     // Disable prism inclusion as we use sitegeist slipstream and include the JS with the element itself
     @context.codeInstancesPresent = false
+
+    head {
+        // Disable goe script inclusion as we use sitegeist slipstream and include the JS with the element itself
+        goeHeadScript >
+    }
 }


### PR DESCRIPTION
Using slipstream to include the js when it's rendered by the content element

<img width="1902" height="1324" alt="CleanShot 2025-07-17 at 13 42 42@2x" src="https://github.com/user-attachments/assets/7edc306b-7f51-48a2-93ef-c7ed881a79e2" />
