### PR TITLE
BUGFIX: Filter blog posts in menu

### DIFF
--- a/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/Documents/Fragment/Menu/Menu.fusion
+++ b/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/Documents/Fragment/Menu/Menu.fusion
@@ -6,7 +6,7 @@ prototype(Neos.NeosIo:Fragment.Menu.Renderer) < prototype(Neos.Fusion:Component)
     items = Neos.Neos:MenuItems {
         entryLevel = 1
         maximumLevels = 2
-        filter = 'Neos.Neos:Document,!Neos.NeosIo:Reference.ShowCase'
+        filter = 'Neos.Neos:Document,!Neos.NeosIo:Reference.ShowCase,!Neos.NeosIo:Post'
         itemUriRenderer = ''
     }
 


### PR DESCRIPTION
Resolves: #626 

We filter the posts as the dropdown doesn't have a big benefit and showing 10 items depending on some condition requires special implementation and a hint that there are "more" posts.
