### PR TITLE
BUGFIX: Add referrer policy to YouTube embed iframe

### DIFF
--- a/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/Content/Youtube.fusion
+++ b/DistributionPackages/Neos.NeosIo/Resources/Private/Fusion/Content/Youtube.fusion
@@ -9,6 +9,7 @@ prototype(Neos.NeosIo:Youtube) < prototype(Neos.Neos:ContentComponent) {
             src={'https://www.youtube-nocookie.com/embed/' + props.video + '?wmode=transparent&rel=0'}
             allowfullscreen=""
             frameborder="0"
+            referrerpolicy="strict-origin-when-cross-origin"
           ></iframe>
           <div class="flexibleEmbed__ratio flexibleEmbed__ratio--16/9"></div>
         </figure>


### PR DESCRIPTION
This fixes the "Error 153 Video player configuration error" that started showing up on the site, by adding the needed `referrerpolicy="strict-origin-when-cross-origin"` attribute.

**How to verify it**

Before:

<img width="889" height="643" alt="image" src="https://github.com/user-attachments/assets/b5263cb3-8f91-4dff-bc6f-1d48beb3c33a" />


After:

<img width="887" height="641" alt="image" src="https://github.com/user-attachments/assets/d96fda84-b93e-4773-9336-d52992980ba2" />
