### PR TITLE
BUGFIX: Fix PictureTag full-width class computed property

### DIFF
--- a/DistributionPackages/Neos.Presentation/Resources/Private/Fusion/Presentation/Image/PictureTag.fusion
+++ b/DistributionPackages/Neos.Presentation/Resources/Private/Fusion/Presentation/Image/PictureTag.fusion
@@ -72,7 +72,7 @@ prototype(Neos.Presentation:Component.PictureTag) < prototype(Neos.Fusion:Compon
         imgClassNames = Neos.Fusion:DataStructure {
             custom = ${props.imgClasses}
             full-width = 'w-full'
-            full-width.@if.noCustomClasses = ${props.imgClasses}
+            full-width.@if.noCustomClasses = ${!props.imgClasses}
             width-auto = 'w-auto'
             width-auto.@if.hasMaxHeight = ${props.maximumHeight}
         }


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MAIN BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**
Fixed: When no `imgClasses` is set, the `w-full` Tailwind class should automatically added to the img tag. There was a logic error reversing this behavior.

This will fix the issue of the stretched-out images of speakers in the Schedule NodeType.

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
