### PR TITLE
FEATURE: NeosCon schedule api

### DIFF
--- a/DistributionPackages/Neos.NeosConIo/Classes/Domain/Dto/RelatedTalk.php
+++ b/DistributionPackages/Neos.NeosConIo/Classes/Domain/Dto/RelatedTalk.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\NeosConIo\Domain\Dto;
+
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Psr\Http\Message\UriInterface;
+
+final readonly class RelatedTalk implements \JsonSerializable
+{
+    public function __construct(
+        public NodeAggregateId $id,
+        public string $title,
+        public string $eventName,
+        public ?UriInterface $url,
+        public bool $hasVideo,
+    ) {
+    }
+
+    /**
+     * @return array{id: string, title: string, event: string, url: string, hasVideo: bool}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id' => $this->id->value,
+            'title' => $this->title,
+            'event' => $this->eventName,
+            'url' => (string)$this->url,
+            'hasVideo' => $this->hasVideo,
+        ];
+    }
+}

--- a/DistributionPackages/Neos.NeosConIo/Classes/Domain/Dto/RelatedTalks.php
+++ b/DistributionPackages/Neos.NeosConIo/Classes/Domain/Dto/RelatedTalks.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\NeosConIo\Domain\Dto;
+
+final readonly class RelatedTalks implements \JsonSerializable
+{
+    /**
+     * @param array<string, RelatedTalk> $values
+     */
+    private function __construct(
+        public array $values
+    ) {
+    }
+
+    /**
+     * @param array<string, RelatedTalk> $talks
+     */
+    public static function fromArray(array $talks): self
+    {
+        return new self($talks);
+    }
+
+    public static function empty(): self
+    {
+        return new self([]);
+    }
+
+    /**
+     * @return RelatedTalk[]|\stdClass
+     */
+    public function jsonSerialize(): array|\stdClass
+    {
+        return $this->values ?: new \stdClass();
+    }
+}

--- a/DistributionPackages/Neos.NeosConIo/Classes/Domain/Dto/Speaker.php
+++ b/DistributionPackages/Neos.NeosConIo/Classes/Domain/Dto/Speaker.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\NeosConIo\Domain\Dto;
+
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Psr\Http\Message\UriInterface;
+
+final readonly class Speaker implements \JsonSerializable
+{
+    public function __construct(
+        public NodeAggregateId $id,
+        public string          $name,
+        public string          $summary,
+        public ?UriInterface   $avatarUrl,
+        public RelatedTalks    $topics,
+        public ?string         $company,
+        public ?string         $position,
+        public ?string         $twitter,
+        public ?string         $github,
+        public ?string         $mastodon,
+    )
+    {
+    }
+
+    /**
+     * @return array{id: string, name: string, summary: string, avatar: string, facts: array{company: string, role: string, github: string, twitter: string, mastodon: string}, topics: RelatedTalks}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id' => $this->id->value,
+            'name' => $this->name,
+            'summary' => $this->summary,
+            'avatar' => (string)$this->avatarUrl,
+            'facts' => [
+                'company' => (string)$this->company,
+                'role' => (string)$this->position,
+                'github' => (string)$this->github,
+                'twitter' => (string)$this->twitter,
+                'mastodon' => (string)$this->mastodon,
+            ],
+            'topics' => $this->topics,
+        ];
+    }
+}

--- a/DistributionPackages/Neos.NeosConIo/Classes/Domain/Dto/Speakers.php
+++ b/DistributionPackages/Neos.NeosConIo/Classes/Domain/Dto/Speakers.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\NeosConIo\Domain\Dto;
+
+final readonly class Speakers implements \JsonSerializable
+{
+    /**
+     * @param array<string, Speaker> $values
+     */
+    private function __construct(
+        public array $values
+    )
+    {
+    }
+
+    /**
+     * @param array<string, Speaker> $values
+     */
+    public static function fromArray(array $values): self
+    {
+        return new self($values);
+    }
+
+    public static function empty(): self
+    {
+        return new self([]);
+    }
+
+    /**
+     * @return Speaker[]|\stdClass
+     */
+    public function jsonSerialize(): array|\stdClass
+    {
+        return $this->values ?: new \stdClass();
+    }
+}

--- a/DistributionPackages/Neos.NeosConIo/Classes/Domain/Dto/Talk.php
+++ b/DistributionPackages/Neos.NeosConIo/Classes/Domain/Dto/Talk.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\NeosConIo\Domain\Dto;
+
+use Neos\ContentRepository\Core\Projection\ContentGraph\Nodes;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
+
+final readonly class Talk implements \JsonSerializable
+{
+    public function __construct(
+        public NodeAggregateId    $id,
+        public string             $title,
+        public string             $description,
+        public string             $type,
+        public \DateTimeInterface $date,
+        public string             $stage,
+        public ?Nodes             $speakers,
+    )
+    {
+    }
+
+    /**
+     * @return array{id: string, title: string, description: string, type: string, start: string, stage: string, speakerIds: string[]}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id' => $this->id->value,
+            'title' => $this->title,
+            'description' => $this->description,
+            'type' => $this->type,
+            'start' => $this->date->format('G:i'),
+            'stage' => $this->stage,
+            'speakerIds' => $this->speakers?->toNodeAggregateIds()->toStringArray() ?? [],
+        ];
+    }
+}

--- a/DistributionPackages/Neos.NeosConIo/Classes/Domain/Dto/Talks.php
+++ b/DistributionPackages/Neos.NeosConIo/Classes/Domain/Dto/Talks.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\NeosConIo\Domain\Dto;
+
+final readonly class Talks implements \JsonSerializable
+{
+    /**
+     * @param array<string, Talk> $values
+     */
+    private function __construct(
+        public array $values
+    )
+    {
+    }
+
+    /**
+     * @param array<string, Talk> $values
+     */
+    public static function fromArray(array $values): self
+    {
+        return new self($values);
+    }
+
+    public static function empty(): self
+    {
+        return new self([]);
+    }
+
+    /**
+     * @return Talk[]|\stdClass
+     */
+    public function jsonSerialize(): array|\stdClass
+    {
+        return $this->values ?: new \stdClass();
+    }
+}

--- a/DistributionPackages/Neos.NeosConIo/Classes/Eel/ScheduleHelper.php
+++ b/DistributionPackages/Neos.NeosConIo/Classes/Eel/ScheduleHelper.php
@@ -13,6 +13,7 @@ namespace Neos\NeosConIo\Eel;
  * source code.
  */
 
+use GuzzleHttp\Psr7\Uri;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindBackReferencesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindReferencesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
@@ -29,6 +30,12 @@ use Neos\Media\Domain\Service\ThumbnailService;
 use Neos\Neos\Domain\NodeLabel\NodeLabelGeneratorInterface;
 use Neos\Neos\FrontendRouting\NodeUriBuilderFactory;
 use Neos\Neos\FrontendRouting\Options;
+use Neos\NeosConIo\Domain\Dto\RelatedTalk;
+use Neos\NeosConIo\Domain\Dto\RelatedTalks;
+use Neos\NeosConIo\Domain\Dto\Speaker;
+use Neos\NeosConIo\Domain\Dto\Speakers;
+use Neos\NeosConIo\Domain\Dto\Talk;
+use Neos\NeosConIo\Domain\Dto\Talks;
 
 /**
  * Eel helper providing schedule-related data transformations for the NeosCon JSON API endpoint.
@@ -60,7 +67,7 @@ class ScheduleHelper implements ProtectedContextAwareInterface
      * strings for all topics of one conference day, sorted chronologically within the day.
      *
      * @param Node[] $topics All topic nodes (Neos.NeosConIo:Talk + Neos.NeosConIo:BreakInSchedule)
-     * @return array<int, array<int, string>>
+     * @return string[][] Array of days, with list of talk ids for that day sorted by their time
      */
     public function topicsPerDay(array $topics): array
     {
@@ -96,34 +103,17 @@ class ScheduleHelper implements ProtectedContextAwareInterface
     }
 
     /**
-     * Indexes an array of nodes into an associative array keyed by their aggregateId value.
-     * Duplicate nodes (same aggregateId) are deduplicated, last write wins.
-     *
-     * @param Node[] $nodes
-     * @return array<string, Node>
-     */
-    public function indexById(array $nodes): array
-    {
-        $result = [];
-        foreach ($nodes as $node) {
-            $result[$node->aggregateId->value] = $node;
-        }
-        return $result;
-    }
-
-    /**
      * Builds the complete topicsById dictionary for the JSON response.
      *
      * Room names and speaker IDs are resolved directly via the ContentRepository subgraph,
      * mirroring the approach used in groupSpeakerTalksByEvent.
      *
      * @param null|Node[] $topics All topic nodes (Talks + Breaks)
-     * @return array<string, array<string, mixed>>
      */
-    public function buildTopicsById(?array $topics): array
+    public function buildTopicsById(?array $topics): Talks
     {
         if (!$topics) {
-            return [];
+            return Talks::empty();
         }
         $firstTopic = $topics[0];
         $nodeTypeManager = $this->contentRepositoryRegistry->get($firstTopic->contentRepositoryId)->getNodeTypeManager();
@@ -135,7 +125,7 @@ class ScheduleHelper implements ProtectedContextAwareInterface
 
         $result = [];
         foreach ($topics as $topic) {
-            $id = $topic->aggregateId->value;
+            $id = $topic->aggregateId;
             $topicNodeType = $nodeTypeManager->getNodeType($topic->nodeTypeName);
             if (!$topicNodeType) {
                 continue;
@@ -143,9 +133,12 @@ class ScheduleHelper implements ProtectedContextAwareInterface
             $isTalk = $topicNodeType->isOfType($talkNodeType->name);
             $talkDate = $topic->properties['talkDate'] ?? null;
             $rawText = $topic->properties['text'] ?? '';
-
             $stage = '';
-            $speakerIds = [];
+            $speakers = null;
+
+            if (!$talkDate instanceof \DateTimeInterface) {
+                continue;
+            }
 
             if ($isTalk) {
                 // Resolve the single room reference → stage name
@@ -156,27 +149,23 @@ class ScheduleHelper implements ProtectedContextAwareInterface
                 $stage = $roomNode?->properties['name'] ?? '';
 
                 // Resolve all speaker references → list of aggregateId strings
-                $speakerIds = $subgraph->findReferences(
+                $speakers = $subgraph->findReferences(
                     $topic->aggregateId,
                     FindReferencesFilter::create(referenceName: 'speakers')
-                )->getNodes()->map(static fn(Node $node) => $node->aggregateId->value);
+                )->getNodes();
             }
 
-            $result[$id] = [
-                'id'          => $id,
-                'title'       => $this->nodeLabelGenerator->getLabel($topic),
-                'description' => $isTalk ? strip_tags($rawText) : $rawText,
-                'type'        => $isTalk
-                                    ? 'TALK'
-                                    : $topic->properties['type'] ?? 'BREAK',
-                'start'       => $talkDate instanceof \DateTimeInterface
-                                    ? $talkDate->format('G:i')
-                                    : '',
-                'stage'       => $stage,
-                'speakerIds'  => $speakerIds,
-            ];
+            $result[$id->value] = new Talk(
+                $id,
+                $this->nodeLabelGenerator->getLabel($topic),
+                trim(strip_tags($rawText)),
+                $isTalk ? 'TALK' : $topic->properties['type'] ?? 'BREAK',
+                $talkDate,
+                $stage,
+                $speakers,
+            );
         }
-        return $result;
+        return Talks::fromArray($result);
     }
 
     /**
@@ -186,11 +175,10 @@ class ScheduleHelper implements ProtectedContextAwareInterface
      * Neos.Neos:ImageUri call it replaces). Speaker topics are resolved by delegating
      * to groupSpeakerTalksByEvent internally.
      *
-     * @param Node[]        $speakers       All speaker nodes for this event
-     * @param ActionRequest $actionRequest  Needed for absolute talk URI generation
-     * @return array<string, array<string, mixed>>
+     * @param Node[] $speakers All speaker nodes for this event
+     * @param ActionRequest $actionRequest Needed for absolute talk URI generation
      */
-    public function buildSpeakersById(array $speakers, ActionRequest $actionRequest): array
+    public function buildSpeakersById(array $speakers, ActionRequest $actionRequest): Speakers
     {
         $thumbnailConfiguration = new ThumbnailConfiguration(
             null,
@@ -200,7 +188,12 @@ class ScheduleHelper implements ProtectedContextAwareInterface
         );
         $result = [];
         foreach ($speakers as $speaker) {
-            $id = $speaker->aggregateId->value;
+            $id = $speaker->aggregateId;
+            $name = trim($speaker->properties['title'] ?? '');
+
+            if (!$name) {
+                continue;
+            }
 
             // Generate a 600×600 thumbnail URI, falling back to '' when no image is set
             $avatarUri = '';
@@ -214,33 +207,29 @@ class ScheduleHelper implements ProtectedContextAwareInterface
                 }
             }
 
-            $result[$id] = [
-                'id'      => $id,
-                'name'    => $speaker->properties['title'] ?? '',
-                'avatar'  => $avatarUri,
-                'facts'   => [
-                    'company'  => $speaker->properties['company'] ?? '',
-                    'role'     => $speaker->properties['position'] ?? '',
-                    'twitter'  => $speaker->properties['twitter'] ?? '',
-                    'github'   => $speaker->properties['github'] ?? '',
-                    'mastodon' => $speaker->properties['mastodon'] ?? '',
-                ],
-                'summary' => strip_tags($speaker->properties['text'] ?? ''),
-                'topics'  => $this->groupSpeakerTalksByEvent($speaker, $actionRequest),
-            ];
+            $result[$id->value] = new Speaker(
+                $id,
+                $name,
+                trim(strip_tags($speaker->properties['text'] ?? '')),
+                $avatarUri ? new Uri($avatarUri) : null,
+                $this->groupSpeakerTalksByEvent($speaker, $actionRequest),
+                $speaker->properties['company'] ?? '',
+                $speaker->properties['position'] ?? '',
+                $speaker->properties['twitter'] ?? '',
+                $speaker->properties['github'] ?? '',
+                $speaker->properties['mastodon'] ?? '',
+            );
         }
-        return $result;
+        return Speakers::fromArray($result);
     }
 
     /**
      * Groups a speaker's talks by talk id with the talks title, event, url and video flag.
-     *
-     * @return array<string, array<string, mixed>>
      */
-    public function groupSpeakerTalksByEvent(?Node $speaker, ActionRequest $actionRequest): array
+    public function groupSpeakerTalksByEvent(?Node $speaker, ActionRequest $actionRequest): RelatedTalks
     {
         if (!$speaker) {
-            return [];
+            return RelatedTalks::empty(); // Return empty object for null speaker to avoid JSON serialization as empty array
         }
 
         $uriBuilder = $this->nodeUriBuilderFactory->forActionRequest($actionRequest);
@@ -269,15 +258,15 @@ class ScheduleHelper implements ProtectedContextAwareInterface
                 $talkUri = null; // Fallback to null if URI generation fails
             }
 
-            $result[$talk->aggregateId->value] = [
-                'id' => $talk->aggregateId->value,
-                'title' => $this->nodeLabelGenerator->getLabel($talk),
-                'event' => $this->nodeLabelGenerator->getLabel($event),
-                'url' => (string)$talkUri,
-                'hasVideo' => (bool)($talk->properties['video'] ?? false),
-            ];
+            $result[$talk->aggregateId->value] = new RelatedTalk(
+                $talk->aggregateId,
+                $this->nodeLabelGenerator->getLabel($talk),
+                $this->nodeLabelGenerator->getLabel($event),
+                $talkUri,
+                (bool)($talk->properties['video'] ?? false),
+            );
         }
-        return $result;
+        return RelatedTalks::fromArray($result);
     }
 
     public function allowsCallOfMethod($methodName): bool

--- a/DistributionPackages/Neos.NeosConIo/Classes/Eel/ScheduleHelper.php
+++ b/DistributionPackages/Neos.NeosConIo/Classes/Eel/ScheduleHelper.php
@@ -66,9 +66,6 @@ class ScheduleHelper implements ProtectedContextAwareInterface
     {
         $days = [];
         foreach ($topics as $topic) {
-            if (!$topic instanceof Node) {
-                continue;
-            }
             $talkDate = $topic->properties['talkDate'] ?? null;
             if (!$talkDate instanceof \DateTimeInterface) {
                 continue;
@@ -89,10 +86,10 @@ class ScheduleHelper implements ProtectedContextAwareInterface
                     }
                     return $dateA <=> $dateB;
                 });
-                return array_values(array_map(
+                return array_map(
                     static fn(Node $topic): string => $topic->aggregateId->value,
                     $dayTopics
-                ));
+                );
             },
             $days
         ));
@@ -109,9 +106,6 @@ class ScheduleHelper implements ProtectedContextAwareInterface
     {
         $result = [];
         foreach ($nodes as $node) {
-            if (!$node instanceof Node) {
-                continue;
-            }
             $result[$node->aggregateId->value] = $node;
         }
         return $result;
@@ -123,25 +117,30 @@ class ScheduleHelper implements ProtectedContextAwareInterface
      * Room names and speaker IDs are resolved directly via the ContentRepository subgraph,
      * mirroring the approach used in groupSpeakerTalksByEvent.
      *
-     * @param Node[] $topics All topic nodes (Talks + Breaks)
+     * @param null|Node[] $topics All topic nodes (Talks + Breaks)
      * @return array<string, array<string, mixed>>
      */
-    public function buildTopicsById(array $topics): array
+    public function buildTopicsById(?array $topics): array
     {
-        $topics = array_filter($topics);
         if (!$topics) {
             return [];
         }
-
         $firstTopic = $topics[0];
         $nodeTypeManager = $this->contentRepositoryRegistry->get($firstTopic->contentRepositoryId)->getNodeTypeManager();
         $talkNodeType = $nodeTypeManager->getNodeType('Neos.NeosConIo:Talk');
+        if (!$talkNodeType) {
+            throw new \RuntimeException('No Neos.NeosConIo:TalkNodeType found', 1779004415);
+        }
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($firstTopic);
 
         $result = [];
         foreach ($topics as $topic) {
             $id = $topic->aggregateId->value;
-            $isTalk = $nodeTypeManager->getNodeType($topic->nodeTypeName)->isOfType($talkNodeType->name);
+            $topicNodeType = $nodeTypeManager->getNodeType($topic->nodeTypeName);
+            if (!$topicNodeType) {
+                continue;
+            }
+            $isTalk = $topicNodeType->isOfType($talkNodeType->name);
             $talkDate = $topic->properties['talkDate'] ?? null;
             $rawText = $topic->properties['text'] ?? '';
 
@@ -157,7 +156,7 @@ class ScheduleHelper implements ProtectedContextAwareInterface
                 $stage = $roomNode?->properties['name'] ?? '';
 
                 // Resolve all speaker references → list of aggregateId strings
-                $speakerIds[] = $subgraph->findReferences(
+                $speakerIds = $subgraph->findReferences(
                     $topic->aggregateId,
                     FindReferencesFilter::create(referenceName: 'speakers')
                 )->getNodes()->map(static fn(Node $node) => $node->aggregateId->value);
@@ -201,10 +200,6 @@ class ScheduleHelper implements ProtectedContextAwareInterface
         );
         $result = [];
         foreach ($speakers as $speaker) {
-            if (!$speaker instanceof Node) {
-                continue;
-            }
-
             $id = $speaker->aggregateId->value;
 
             // Generate a 600×600 thumbnail URI, falling back to '' when no image is set
@@ -238,13 +233,9 @@ class ScheduleHelper implements ProtectedContextAwareInterface
     }
 
     /**
-     * Groups a speaker's talks by the title of the event they belong to.
+     * Groups a speaker's talks by talk id with the talks title, event, url and video flag.
      *
-     * Returns an associative array whose keys are event titles and whose values are
-     * sequential arrays of talk aggregateId strings, e.g.:
-     *   ['Neos Conference 2026' => ['uuid-a', 'uuid-b'], 'Neos Conference 2025' => ['uuid-c']]
-     *
-     * @return array<string, array<int, string>>
+     * @return array<string, array<string, mixed>>
      */
     public function groupSpeakerTalksByEvent(?Node $speaker, ActionRequest $actionRequest): array
     {
@@ -282,7 +273,7 @@ class ScheduleHelper implements ProtectedContextAwareInterface
                 'id' => $talk->aggregateId->value,
                 'title' => $this->nodeLabelGenerator->getLabel($talk),
                 'event' => $this->nodeLabelGenerator->getLabel($event),
-                'url' => $talkUri,
+                'url' => (string)$talkUri,
                 'hasVideo' => (bool)($talk->properties['video'] ?? false),
             ];
         }

--- a/DistributionPackages/Neos.NeosConIo/Classes/Eel/ScheduleHelper.php
+++ b/DistributionPackages/Neos.NeosConIo/Classes/Eel/ScheduleHelper.php
@@ -1,0 +1,296 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\NeosConIo\Eel;
+
+/*
+ * This file is part of the Neos.NeosConIo package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindBackReferencesFilter;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindReferencesFilter;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
+use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
+use Neos\Eel\ProtectedContextAwareInterface;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\ActionRequest;
+use Neos\Flow\ResourceManagement\ResourceManager;
+use Neos\Media\Domain\Model\AssetInterface;
+use Neos\Media\Domain\Model\ThumbnailConfiguration;
+use Neos\Media\Domain\Service\AssetService;
+use Neos\Media\Domain\Service\ThumbnailService;
+use Neos\Neos\Domain\NodeLabel\NodeLabelGeneratorInterface;
+use Neos\Neos\FrontendRouting\NodeUriBuilderFactory;
+use Neos\Neos\FrontendRouting\Options;
+
+/**
+ * Eel helper providing schedule-related data transformations for the NeosCon JSON API endpoint.
+ */
+class ScheduleHelper implements ProtectedContextAwareInterface
+{
+    #[Flow\Inject]
+    protected ContentRepositoryRegistry $contentRepositoryRegistry;
+
+    #[Flow\Inject]
+    protected NodeLabelGeneratorInterface $nodeLabelGenerator;
+
+    #[Flow\Inject]
+    protected NodeUriBuilderFactory $nodeUriBuilderFactory;
+
+    #[Flow\Inject]
+    protected ThumbnailService $thumbnailService;
+
+    #[Flow\Inject]
+    protected ResourceManager $resourceManager;
+
+    #[Flow\Inject]
+    protected AssetService $assetService;
+
+    /**
+     * Groups topic nodes (Talks + Breaks) by the date portion of their talkDate property.
+     *
+     * Returns an ordered array of arrays, each inner array containing the aggregateId
+     * strings for all topics of one conference day, sorted chronologically within the day.
+     *
+     * @param Node[] $topics All topic nodes (Neos.NeosConIo:Talk + Neos.NeosConIo:BreakInSchedule)
+     * @return array<int, array<int, string>>
+     */
+    public function topicsPerDay(array $topics): array
+    {
+        $days = [];
+        foreach ($topics as $topic) {
+            if (!$topic instanceof Node) {
+                continue;
+            }
+            $talkDate = $topic->properties['talkDate'] ?? null;
+            if (!$talkDate instanceof \DateTimeInterface) {
+                continue;
+            }
+            $dateKey = $talkDate->format('Y-m-d');
+            $days[$dateKey][] = $topic;
+        }
+
+        ksort($days);
+
+        return array_values(array_map(
+            static function (array $dayTopics): array {
+                usort($dayTopics, static function (Node $a, Node $b): int {
+                    $dateA = $a->properties['talkDate'] ?? null;
+                    $dateB = $b->properties['talkDate'] ?? null;
+                    if (!$dateA instanceof \DateTimeInterface || !$dateB instanceof \DateTimeInterface) {
+                        return 0;
+                    }
+                    return $dateA <=> $dateB;
+                });
+                return array_values(array_map(
+                    static fn(Node $topic): string => $topic->aggregateId->value,
+                    $dayTopics
+                ));
+            },
+            $days
+        ));
+    }
+
+    /**
+     * Indexes an array of nodes into an associative array keyed by their aggregateId value.
+     * Duplicate nodes (same aggregateId) are deduplicated, last write wins.
+     *
+     * @param Node[] $nodes
+     * @return array<string, Node>
+     */
+    public function indexById(array $nodes): array
+    {
+        $result = [];
+        foreach ($nodes as $node) {
+            if (!$node instanceof Node) {
+                continue;
+            }
+            $result[$node->aggregateId->value] = $node;
+        }
+        return $result;
+    }
+
+    /**
+     * Builds the complete topicsById dictionary for the JSON response.
+     *
+     * Room names and speaker IDs are resolved directly via the ContentRepository subgraph,
+     * mirroring the approach used in groupSpeakerTalksByEvent.
+     *
+     * @param Node[] $topics All topic nodes (Talks + Breaks)
+     * @return array<string, array<string, mixed>>
+     */
+    public function buildTopicsById(array $topics): array
+    {
+        $topics = array_filter($topics);
+        if (!$topics) {
+            return [];
+        }
+
+        $firstTopic = $topics[0];
+        $nodeTypeManager = $this->contentRepositoryRegistry->get($firstTopic->contentRepositoryId)->getNodeTypeManager();
+        $talkNodeType = $nodeTypeManager->getNodeType('Neos.NeosConIo:Talk');
+        $subgraph = $this->contentRepositoryRegistry->subgraphForNode($firstTopic);
+
+        $result = [];
+        foreach ($topics as $topic) {
+            $id = $topic->aggregateId->value;
+            $isTalk = $nodeTypeManager->getNodeType($topic->nodeTypeName)->isOfType($talkNodeType->name);
+            $talkDate = $topic->properties['talkDate'] ?? null;
+            $rawText = $topic->properties['text'] ?? '';
+
+            $stage = '';
+            $speakerIds = [];
+
+            if ($isTalk) {
+                // Resolve the single room reference → stage name
+                $roomNode = $subgraph->findReferences(
+                    $topic->aggregateId,
+                    FindReferencesFilter::create(referenceName: 'room')
+                )->getNodes()->first();
+                $stage = $roomNode?->properties['name'] ?? '';
+
+                // Resolve all speaker references → list of aggregateId strings
+                $speakerIds[] = $subgraph->findReferences(
+                    $topic->aggregateId,
+                    FindReferencesFilter::create(referenceName: 'speakers')
+                )->getNodes()->map(static fn(Node $node) => $node->aggregateId->value);
+            }
+
+            $result[$id] = [
+                'id'          => $id,
+                'title'       => $this->nodeLabelGenerator->getLabel($topic),
+                'description' => $isTalk ? strip_tags($rawText) : $rawText,
+                'type'        => $isTalk
+                                    ? 'TALK'
+                                    : $topic->properties['type'] ?? 'BREAK',
+                'start'       => $talkDate instanceof \DateTimeInterface
+                                    ? $talkDate->format('G:i')
+                                    : '',
+                'stage'       => $stage,
+                'speakerIds'  => $speakerIds,
+            ];
+        }
+        return $result;
+    }
+
+    /**
+     * Builds the complete speakersById dictionary for the JSON response.
+     *
+     * Avatar thumbnails are generated via ThumbnailService (600×600 max, same as the
+     * Neos.Neos:ImageUri call it replaces). Speaker topics are resolved by delegating
+     * to groupSpeakerTalksByEvent internally.
+     *
+     * @param Node[]        $speakers       All speaker nodes for this event
+     * @param ActionRequest $actionRequest  Needed for absolute talk URI generation
+     * @return array<string, array<string, mixed>>
+     */
+    public function buildSpeakersById(array $speakers, ActionRequest $actionRequest): array
+    {
+        $thumbnailConfiguration = new ThumbnailConfiguration(
+            null,
+            600,
+            null,
+            600,
+        );
+        $result = [];
+        foreach ($speakers as $speaker) {
+            if (!$speaker instanceof Node) {
+                continue;
+            }
+
+            $id = $speaker->aggregateId->value;
+
+            // Generate a 600×600 thumbnail URI, falling back to '' when no image is set
+            $avatarUri = '';
+            $image = $speaker->properties['image'] ?? null;
+            if ($image instanceof AssetInterface) {
+                try {
+                    $thumbnailData = $this->assetService->getThumbnailUriAndSizeForAsset($image, $thumbnailConfiguration, $actionRequest);
+                    $avatarUri = $thumbnailData['src'] ?? null;
+                } catch (\Exception) {
+                    // Leave avatarUri as empty on any failure
+                }
+            }
+
+            $result[$id] = [
+                'id'      => $id,
+                'name'    => $speaker->properties['title'] ?? '',
+                'avatar'  => $avatarUri,
+                'facts'   => [
+                    'company'  => $speaker->properties['company'] ?? '',
+                    'role'     => $speaker->properties['position'] ?? '',
+                    'twitter'  => $speaker->properties['twitter'] ?? '',
+                    'github'   => $speaker->properties['github'] ?? '',
+                    'mastodon' => $speaker->properties['mastodon'] ?? '',
+                ],
+                'summary' => strip_tags($speaker->properties['text'] ?? ''),
+                'topics'  => $this->groupSpeakerTalksByEvent($speaker, $actionRequest),
+            ];
+        }
+        return $result;
+    }
+
+    /**
+     * Groups a speaker's talks by the title of the event they belong to.
+     *
+     * Returns an associative array whose keys are event titles and whose values are
+     * sequential arrays of talk aggregateId strings, e.g.:
+     *   ['Neos Conference 2026' => ['uuid-a', 'uuid-b'], 'Neos Conference 2025' => ['uuid-c']]
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function groupSpeakerTalksByEvent(?Node $speaker, ActionRequest $actionRequest): array
+    {
+        if (!$speaker) {
+            return [];
+        }
+
+        $uriBuilder = $this->nodeUriBuilderFactory->forActionRequest($actionRequest);
+
+        $subgraph = $this->contentRepositoryRegistry->subgraphForNode($speaker);
+        $speakerTalks = $subgraph->findBackReferences(
+            $speaker->aggregateId,
+            FindBackReferencesFilter::create(nodeTypes: 'Neos.NeosConIo:Talk', referenceName: 'speakers')
+        )->getNodes();
+
+        $result = [];
+        foreach ($speakerTalks as $talk) {
+            $event = $subgraph->findReferences(
+                $talk->aggregateId,
+                FindReferencesFilter::create(nodeTypes: 'Neos.NeosConIo:Event', referenceName: 'event')
+            )->getNodes()->first();
+
+            // Ignore talks without events
+            if (!$event) {
+                continue;
+            }
+
+            try {
+                $talkUri = $uriBuilder->uriFor(NodeAddress::fromNode($talk), Options::createForceAbsolute());
+            } catch (\Exception) {
+                $talkUri = null; // Fallback to null if URI generation fails
+            }
+
+            $result[$talk->aggregateId->value] = [
+                'id' => $talk->aggregateId->value,
+                'title' => $this->nodeLabelGenerator->getLabel($talk),
+                'event' => $this->nodeLabelGenerator->getLabel($event),
+                'url' => $talkUri,
+                'hasVideo' => (bool)($talk->properties['video'] ?? false),
+            ];
+        }
+        return $result;
+    }
+
+    public function allowsCallOfMethod($methodName): bool
+    {
+        return true;
+    }
+}

--- a/DistributionPackages/Neos.NeosConIo/Configuration/Routes.yaml
+++ b/DistributionPackages/Neos.NeosConIo/Configuration/Routes.yaml
@@ -1,0 +1,13 @@
+- name: 'NeosCon Schedule JSON API'
+  uriPattern: '{node}.json'
+  defaults:
+    '@package': 'Neos.Neos'
+    '@controller': 'Frontend\Node'
+    '@action': 'show'
+    '@format': 'json'
+  routeParts:
+    'node':
+      handler: 'Neos\Neos\FrontendRouting\FrontendNodeRoutePartHandlerInterface'
+      options:
+        uriPathSuffix: ''
+        nodeType: 'Neos.NeosConIo:Document.SchedulePage'

--- a/DistributionPackages/Neos.NeosConIo/Configuration/Settings.Flow.yaml
+++ b/DistributionPackages/Neos.NeosConIo/Configuration/Settings.Flow.yaml
@@ -1,0 +1,5 @@
+Neos:
+  Flow:
+    mvc:
+      routes:
+        'Neos.NeosConIo': {}

--- a/DistributionPackages/Neos.NeosConIo/Configuration/Settings.yaml
+++ b/DistributionPackages/Neos.NeosConIo/Configuration/Settings.yaml
@@ -1,4 +1,3 @@
-
 Neos:
   Neos:
     nodeTypes:
@@ -10,3 +9,4 @@ Neos:
   Fusion:
     defaultContext:
       'Neos.NeosConIo.Date': 'Neos\NeosConIo\Eel\DateHelper'
+      'Neos.NeosConIo.Schedule': 'Neos\NeosConIo\Eel\ScheduleHelper'

--- a/DistributionPackages/Neos.NeosConIo/NodeTypes/Content/BreakInSchedule.yaml
+++ b/DistributionPackages/Neos.NeosConIo/NodeTypes/Content/BreakInSchedule.yaml
@@ -17,6 +17,20 @@
         label: 'Title'
         inspector:
           group: 'breakSettings'
+    type:
+      type: string
+      ui:
+        label: 'Schedule type'
+        reloadIfChanged: true
+        inspector:
+          group: 'breakSettings'
+          editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
+          editorOptions:
+            allowEmpty: true
+            placeholder: 'Break (coffee, lunch, …)'
+            values:
+              SPECIAL:
+                label: 'Special (social event, …)'
     talkDate:
       type: DateTime
       ui:

--- a/DistributionPackages/Neos.NeosConIo/NodeTypes/Documents/SchedulePage.yaml
+++ b/DistributionPackages/Neos.NeosConIo/NodeTypes/Documents/SchedulePage.yaml
@@ -1,0 +1,43 @@
+'Neos.NeosConIo:Document.SchedulePage':
+  superTypes:
+    'Neos.NodeTypes:Page': true
+    'Neos.NeosConIo:Mixin.EventRelated': true
+  ui:
+    label: 'Schedule Overview'
+    icon: 'calendar-days'
+    group: neoscon
+    inspector:
+      groups:
+        scheduleSettings:
+          label: 'Schedule Settings'
+          icon: 'calendar-days'
+  references:
+    event:
+      constraints:
+        nodeTypes:
+          'Neos.NeosConIo:Event': true
+        maxItems: 1
+      ui:
+        label: 'Current event'
+        reloadIfChanged: true
+        inspector:
+          group: 'scheduleSettings'
+          editorOptions:
+            nodeTypes: ['Neos.NeosConIo:Event']
+  properties:
+    # TODO: Use Time type or validation for time format
+    votingEnd:
+      type: string
+      ui:
+        label: 'Voting End Time (e.g. 15:45)'
+        inspector:
+          group: 'scheduleSettings'
+          editorOptions:
+            placeholder: '15:45'
+    surveyLink:
+      type: string
+      ui:
+        label: 'Post-Con Survey Link'
+        inspector:
+          group: 'scheduleSettings'
+          editor: Neos.Neos/Inspector/Editors/LinkEditor

--- a/DistributionPackages/Neos.NeosConIo/NodeTypes/Override/NeosIo/RootPage.yaml
+++ b/DistributionPackages/Neos.NeosConIo/NodeTypes/Override/NeosIo/RootPage.yaml
@@ -1,6 +1,10 @@
+##
+# TODO: Introduce a separate root page type for the conference site and move the constraints there instead of overriding the RootPage of NeosIo
+#
 'Neos.NeosIo:RootPage':
   constraints:
     nodeTypes:
       'Neos.NeosConIo:Speakers': true
       'Neos.NeosConIo:Events': true
       'Neos.NeosConIo:Talks': true
+      'Neos.NeosConIo:Document.SchedulePage': true

--- a/DistributionPackages/Neos.NeosConIo/Resources/Private/Fusion/Documents/SchedulePage/SchedulePage.Json.fusion
+++ b/DistributionPackages/Neos.NeosConIo/Resources/Private/Fusion/Documents/SchedulePage/SchedulePage.Json.fusion
@@ -1,0 +1,82 @@
+/**
+ * Renders the NeosCon schedule as a JSON API response.
+ *
+ * The output structure mirrors the neos-con-app.json used by the mobile app:
+ *   - topicsPerDay   – array of arrays of topic aggregateId strings, one inner array per day
+ *   - topicsById     – dict of all topics (Talks + Breaks) keyed by aggregateId
+ *   - speakersById   – dict of all speakers keyed by aggregateId
+ *   - votingEnd      – last talk start time (from the SchedulePage property)
+ *   - surveyLink     – post-con survey URL (from the SchedulePage property)
+ *
+ * Access: <schedule-page-url>.json
+ */
+prototype(Neos.NeosConIo:Component.Schedule.Json) < prototype(Neos.Fusion:Component) {
+    eventNode = ${q(documentNode).referenceNodes('event').get(0)}
+    votingEnd = ${documentNode.properties.votingEnd}
+    surveyLink = ${documentNode.properties.surveyLink}
+
+    @private {
+        // All Talks and Breaks for the referenced Event, combined into a single list
+        allTalks = ${props.eventNode ? q(props.eventNode).backReferenceNodes('event').filter('[instanceof Neos.NeosConIo:Talk]').get() : []}
+        allBreaks = ${props.eventNode ? q(props.eventNode).find('[instanceof Neos.NeosConIo:BreakInSchedule]').get() : []}
+        allTopics = ${Array.concat(private.allTalks, private.allBreaks)}
+
+        // All Speakers linked to this Event via the Speaker.event back-reference
+        allSpeakers = ${props.eventNode ? q(props.eventNode).backReferenceNodes('event').filter('[instanceof Neos.NeosConIo:Speaker]').get() : []}
+    }
+
+    renderer = Neos.Fusion:Http.Message {
+        httpResponseHead {
+            headers.Content-Type = 'application/json'
+        }
+
+        data = Neos.Fusion:DataStructure {
+            // Timestamp of when the schedule data was last updated, used for client-side caching.
+            lastUpdated = ${Date.now().timestamp}
+
+            // [ [dayOneId, dayOneId2, …], [dayTwoId, …] ]
+            topicsPerDay = ${Neos.NeosConIo.Schedule.topicsPerDay(private.allTopics)}
+
+            // { "<aggregateId>": { id, title, description, type, start, stage, speakerIds } }
+            topicsById = ${Neos.NeosConIo.Schedule.buildTopicsById(private.allTopics)}
+
+            // { "<aggregateId>": { id, name, avatar, facts, summary, topics } }
+            // Avatar thumbnails, facts and talk topics are all resolved in PHP.
+            speakersById = ${Neos.NeosConIo.Schedule.buildSpeakersById(private.allSpeakers, request)}
+
+            votingEnd = ${props.votingEnd}
+            surveyLink = ${props.surveyLink}
+            surveyLink.@process.convertUris = Neos.Neos:ConvertUris {
+                absolute = true
+            }
+
+            @process.json = ${Json.stringify(value)}
+        }
+    }
+
+    @cache {
+        mode = 'cached'
+        maximumLifetime = 3600
+        entryIdentifier {
+            documentNode = ${Neos.Caching.entryIdentifierForNode(documentNode)}
+            format = 'json'
+        }
+        entryTags {
+            documentNode = ${Neos.Caching.nodeTag(documentNode)}
+            events = ${Neos.Caching.nodeTypeTag('Neos.NeosConIo:Event', site)}
+            talks = ${Neos.Caching.nodeTypeTag('Neos.NeosConIo:Talk', site)}
+            speakers = ${Neos.Caching.nodeTypeTag('Neos.NeosConIo:Speaker', site)}
+            breaks = ${Neos.Caching.nodeTypeTag('Neos.NeosConIo:BreakInSchedule', site)}
+            rooms = ${Neos.Caching.nodeTypeTag('Neos.NeosConIo:Room', site)}
+        }
+    }
+}
+
+// ── Route into the Neos root rendering pipeline ──────────────────────────────
+root {
+    neosConScheduleJson {
+        @position = 'before format'
+        condition = ${request.format == 'json' && q(documentNode).is('[instanceof Neos.NeosConIo:Document.SchedulePage]')}
+        renderer = Neos.NeosConIo:Component.Schedule.Json
+    }
+}

--- a/DistributionPackages/Neos.NeosConIo/Resources/Private/Fusion/Documents/SchedulePage/SchedulePage.fusion
+++ b/DistributionPackages/Neos.NeosConIo/Resources/Private/Fusion/Documents/SchedulePage/SchedulePage.fusion
@@ -1,0 +1,2 @@
+prototype(Neos.NeosConIo:Document.SchedulePage) < prototype(Neos.NeosIo:DefaultPage) {
+}


### PR DESCRIPTION
For the api to work:
1. the "schedule" page type needs to be switched to the new "Schedule page" nodetype
2. the latest event referenced on this page. 
3. Then it is reachable f.e. via `/schedule.json`.

The entries are cached for 1 hour and refreshed when anything related to the schedule changes.