### PR TITLE
BUG: NeosCon schedule api: decoding special chars for topic title, description, speaker summary

### DIFF
--- a/DistributionPackages/Neos.NeosConIo/Classes/Eel/ScheduleHelper.php
+++ b/DistributionPackages/Neos.NeosConIo/Classes/Eel/ScheduleHelper.php
@@ -161,7 +161,7 @@ class ScheduleHelper implements ProtectedContextAwareInterface
 
             $result[$id->value] = new Talk(
                 $id,
-                $this->htmlDecodeAndTrim($this->nodeLabelGenerator->getLabel($topic) ?? ''),
+                $this->htmlDecodeAndTrim($this->nodeLabelGenerator->getLabel($topic)),
                 $this->htmlDecodeAndTrim(strip_tags($rawText  ?? '')),
                 $isTalk ? 'TALK' : ($topic->properties['type'] ?? 'BREAK'),
                 $talkDate,
@@ -193,7 +193,7 @@ class ScheduleHelper implements ProtectedContextAwareInterface
         $result = [];
         foreach ($speakers as $speaker) {
             $id = $speaker->aggregateId;
-            $name = $this->htmlDecodeAndTrim($speaker->properties['title'] ?? '');
+            $name = $this->htmlDecodeAndTrim($speaker->properties['title']);
 
             if (!$name) {
                 continue;
@@ -264,8 +264,8 @@ class ScheduleHelper implements ProtectedContextAwareInterface
 
             $result[$talk->aggregateId->value] = new RelatedTalk(
                 $talk->aggregateId,
-                $this->htmlDecodeAndTrim($this->nodeLabelGenerator->getLabel($talk) ?? ''),
-                $this->htmlDecodeAndTrim($this->nodeLabelGenerator->getLabel($event) ?? ''),
+                $this->htmlDecodeAndTrim($this->nodeLabelGenerator->getLabel($talk)),
+                $this->htmlDecodeAndTrim($this->nodeLabelGenerator->getLabel($event)),
                 $talkUri,
                 (bool)($talk->properties['video'] ?? false),
             );
@@ -278,8 +278,8 @@ class ScheduleHelper implements ProtectedContextAwareInterface
         return true;
     }
 
-    private function htmlDecodeAndTrim(string $text): string
+    private function htmlDecodeAndTrim(?string $text): string
     {
-        return trim(html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+        return trim(html_entity_decode($text ?? '', ENT_QUOTES | ENT_HTML5, 'UTF-8'));
     }
 }

--- a/DistributionPackages/Neos.NeosConIo/Classes/Eel/ScheduleHelper.php
+++ b/DistributionPackages/Neos.NeosConIo/Classes/Eel/ScheduleHelper.php
@@ -161,8 +161,8 @@ class ScheduleHelper implements ProtectedContextAwareInterface
 
             $result[$id->value] = new Talk(
                 $id,
-                $this->nodeLabelGenerator->getLabel($topic),
-                trim(strip_tags($rawText)),
+                html_entity_decode($this->nodeLabelGenerator->getLabel($topic), ENT_QUOTES | ENT_HTML5, 'UTF-8'),
+                trim(html_entity_decode(strip_tags($rawText))),
                 $isTalk ? 'TALK' : ($topic->properties['type'] ?? 'BREAK'),
                 $talkDate,
                 $stage,
@@ -193,7 +193,7 @@ class ScheduleHelper implements ProtectedContextAwareInterface
         $result = [];
         foreach ($speakers as $speaker) {
             $id = $speaker->aggregateId;
-            $name = trim($speaker->properties['title'] ?? '');
+            $name = trim(html_entity_decode($speaker->properties['title'] ?? '', ENT_QUOTES | ENT_HTML5, 'UTF-8'));
 
             if (!$name) {
                 continue;
@@ -214,7 +214,7 @@ class ScheduleHelper implements ProtectedContextAwareInterface
             $result[$id->value] = new Speaker(
                 $id,
                 $name,
-                trim(strip_tags($speaker->properties['text'] ?? '')),
+                trim(html_entity_decode(strip_tags($speaker->properties['text'] ?? ''))),
                 $avatarUri ? new Uri($avatarUri) : null,
                 $this->groupSpeakerTalksByEvent($speaker, $actionRequest),
                 $speaker->properties['company'] ?? '',
@@ -264,8 +264,8 @@ class ScheduleHelper implements ProtectedContextAwareInterface
 
             $result[$talk->aggregateId->value] = new RelatedTalk(
                 $talk->aggregateId,
-                $this->nodeLabelGenerator->getLabel($talk),
-                $this->nodeLabelGenerator->getLabel($event),
+                html_entity_decode($this->nodeLabelGenerator->getLabel($talk), ENT_QUOTES | ENT_HTML5, 'UTF-8'),
+                html_entity_decode($this->nodeLabelGenerator->getLabel($event), ENT_QUOTES | ENT_HTML5, 'UTF-8'),
                 $talkUri,
                 (bool)($talk->properties['video'] ?? false),
             );

--- a/DistributionPackages/Neos.NeosConIo/Classes/Eel/ScheduleHelper.php
+++ b/DistributionPackages/Neos.NeosConIo/Classes/Eel/ScheduleHelper.php
@@ -161,8 +161,8 @@ class ScheduleHelper implements ProtectedContextAwareInterface
 
             $result[$id->value] = new Talk(
                 $id,
-                html_entity_decode($this->nodeLabelGenerator->getLabel($topic), ENT_QUOTES | ENT_HTML5, 'UTF-8'),
-                trim(html_entity_decode(strip_tags($rawText), ENT_QUOTES | ENT_HTML5, 'UTF-8')),
+                $this->htmlDecodeAndTrim($this->nodeLabelGenerator->getLabel($topic) ?? ''),
+                $this->htmlDecodeAndTrim(strip_tags($rawText  ?? '')),
                 $isTalk ? 'TALK' : ($topic->properties['type'] ?? 'BREAK'),
                 $talkDate,
                 $stage,
@@ -193,7 +193,7 @@ class ScheduleHelper implements ProtectedContextAwareInterface
         $result = [];
         foreach ($speakers as $speaker) {
             $id = $speaker->aggregateId;
-            $name = trim(html_entity_decode($speaker->properties['title'] ?? '', ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+            $name = $this->htmlDecodeAndTrim($speaker->properties['title'] ?? '');
 
             if (!$name) {
                 continue;
@@ -214,7 +214,7 @@ class ScheduleHelper implements ProtectedContextAwareInterface
             $result[$id->value] = new Speaker(
                 $id,
                 $name,
-                trim(html_entity_decode(strip_tags($speaker->properties['text'] ?? ''), ENT_QUOTES | ENT_HTML5, 'UTF-8')),
+                $this->htmlDecodeAndTrim(strip_tags($speaker->properties['text'] ?? '')),
                 $avatarUri ? new Uri($avatarUri) : null,
                 $this->groupSpeakerTalksByEvent($speaker, $actionRequest),
                 $speaker->properties['company'] ?? '',
@@ -264,8 +264,8 @@ class ScheduleHelper implements ProtectedContextAwareInterface
 
             $result[$talk->aggregateId->value] = new RelatedTalk(
                 $talk->aggregateId,
-                html_entity_decode($this->nodeLabelGenerator->getLabel($talk), ENT_QUOTES | ENT_HTML5, 'UTF-8'),
-                html_entity_decode($this->nodeLabelGenerator->getLabel($event), ENT_QUOTES | ENT_HTML5, 'UTF-8'),
+                $this->htmlDecodeAndTrim($this->nodeLabelGenerator->getLabel($talk) ?? ''),
+                $this->htmlDecodeAndTrim($this->nodeLabelGenerator->getLabel($event) ?? ''),
                 $talkUri,
                 (bool)($talk->properties['video'] ?? false),
             );
@@ -276,5 +276,10 @@ class ScheduleHelper implements ProtectedContextAwareInterface
     public function allowsCallOfMethod($methodName): bool
     {
         return true;
+    }
+
+    private function htmlDecodeAndTrim(string $text): string
+    {
+        return trim(html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
     }
 }

--- a/DistributionPackages/Neos.NeosConIo/Classes/Eel/ScheduleHelper.php
+++ b/DistributionPackages/Neos.NeosConIo/Classes/Eel/ScheduleHelper.php
@@ -162,7 +162,7 @@ class ScheduleHelper implements ProtectedContextAwareInterface
             $result[$id->value] = new Talk(
                 $id,
                 $this->htmlDecodeAndTrim($this->nodeLabelGenerator->getLabel($topic)),
-                $this->htmlDecodeAndTrim(strip_tags($rawText  ?? '')),
+                $this->htmlDecodeAndTrim(strip_tags($rawText)),
                 $isTalk ? 'TALK' : ($topic->properties['type'] ?? 'BREAK'),
                 $talkDate,
                 $stage,

--- a/DistributionPackages/Neos.NeosConIo/Classes/Eel/ScheduleHelper.php
+++ b/DistributionPackages/Neos.NeosConIo/Classes/Eel/ScheduleHelper.php
@@ -162,7 +162,7 @@ class ScheduleHelper implements ProtectedContextAwareInterface
             $result[$id->value] = new Talk(
                 $id,
                 html_entity_decode($this->nodeLabelGenerator->getLabel($topic), ENT_QUOTES | ENT_HTML5, 'UTF-8'),
-                trim(html_entity_decode(strip_tags($rawText))),
+                trim(html_entity_decode(strip_tags($rawText), ENT_QUOTES | ENT_HTML5, 'UTF-8')),
                 $isTalk ? 'TALK' : ($topic->properties['type'] ?? 'BREAK'),
                 $talkDate,
                 $stage,
@@ -214,7 +214,7 @@ class ScheduleHelper implements ProtectedContextAwareInterface
             $result[$id->value] = new Speaker(
                 $id,
                 $name,
-                trim(html_entity_decode(strip_tags($speaker->properties['text'] ?? ''))),
+                trim(html_entity_decode(strip_tags($speaker->properties['text'] ?? ''), ENT_QUOTES | ENT_HTML5, 'UTF-8')),
                 $avatarUri ? new Uri($avatarUri) : null,
                 $this->groupSpeakerTalksByEvent($speaker, $actionRequest),
                 $speaker->properties['company'] ?? '',


### PR DESCRIPTION
Schedule api updated to decode html special characters so a readable string is returned.

goal:
* `&` instead of `&amp;`
* `&nbsp;` should always be ` `
* title & description, summary etc properly trimmed strings